### PR TITLE
Handle cases where app exits or fails without exceptions

### DIFF
--- a/lib/boom.ex
+++ b/lib/boom.ex
@@ -9,16 +9,28 @@ defmodule Boom do
         try do
           case unquote(config) do
             [notifier: notifier, options: options] ->
-              notifier.notify(reason, stack, options)
+              notify(notifier, reason, stack, options)
 
             notifiers_config when is_list(notifiers_config) ->
               for [notifier: notifier, options: options] <- notifiers_config do
-                notifier.notify(reason, stack, options)
+                notify(notifier, reason, stack, options)
               end
           end
         rescue
           e -> IO.inspect(e, label: "[Boom] Error sending exception")
         end
+      end
+
+      defp notify(notifier, %{message: reason}, stack, options) do
+        notifier.notify(reason, stack, options)
+      end
+
+      defp notify(notifier, reason, stack, options) when is_binary(reason) do
+        notify(notifier, %{message: reason}, stack, options)
+      end
+
+      defp notify(notifier, reason, stack, options) do
+        notify(notifier, %{message: inspect(reason)}, stack, options)
       end
     end
   end

--- a/lib/boom/mail_notifier.ex
+++ b/lib/boom/mail_notifier.ex
@@ -8,7 +8,7 @@ defmodule Boom.MailNotifier do
           {:mailer, module()} | {:from, String.t()} | {:to, String.t()} | {:subject, String.t()}
   @type options :: [option]
 
-  @spec notify(Boom.Notifier.reason(), [String.t()], options) :: no_return()
+  @spec notify(String.t(), [String.t()], options) :: no_return()
   def notify(reason, stack, options) do
     [mailer: mailer, from: email_from, to: email_to, subject: subject] = options
 
@@ -16,7 +16,7 @@ defmodule Boom.MailNotifier do
       new_email()
       |> to(email_to)
       |> from(email_from)
-      |> subject("#{subject}: #{reason.message}")
+      |> subject("#{subject}: #{reason}")
       |> html_body(stack_to_html(stack))
       |> text_body(stack_to_string(stack))
 

--- a/lib/boom/notifier.ex
+++ b/lib/boom/notifier.ex
@@ -1,4 +1,3 @@
 defmodule Boom.Notifier do
-  @type reason :: atom() | {:message, String.t()}
-  @callback notify(reason, [String.t()], keyword(String.t())) :: no_return()
+  @callback notify(String.t(), [String.t()], keyword(String.t())) :: no_return()
 end


### PR DESCRIPTION
This PR cover cases where Phoenix app fails due to `exit` or `throw` statements. This situation is sending params to `Plug.ErrorHandler. handle_errors` in a different way than exceptions, and it is now properly handled.

Note we cover all cases in order to make sure we always pass a string `reason` to the `notifier` module.