### PR TITLE
Add options validation

### DIFF
--- a/lib/boom_notifier.ex
+++ b/lib/boom_notifier.ex
@@ -29,9 +29,7 @@ defmodule BoomNotifier do
         run_callback(settings, callback)
 
       notifiers_settings when is_list(notifiers_settings) ->
-        for notifier_settings <- notifiers_settings do
-          run_callback(notifier_settings, callback)
-        end
+        Enum.each(notifiers_settings, &run_callback(&1, callback))
     end
   end
 

--- a/lib/boom_notifier.ex
+++ b/lib/boom_notifier.ex
@@ -1,8 +1,27 @@
 defmodule BoomNotifier do
   @moduledoc false
+
   # Notify the exception to all the defined notifiers
 
   alias BoomNotifier.ErrorStorage
+
+  def walkthrough_notifiers(settings, callback) do
+    case Keyword.get(settings, :notifiers) do
+      nil ->
+        with {:ok, notifier} <- Keyword.fetch(settings, :notifier),
+             {:ok, options} <- Keyword.fetch(settings, :options) do
+          callback.(notifier, options)
+        end
+
+      notifiers_config when is_list(notifiers_config) ->
+        for notifier_config <- notifiers_config do
+          with {:ok, notifier} <- Keyword.fetch(notifier_config, :notifier),
+               {:ok, options} <- Keyword.fetch(notifier_config, :options) do
+            callback.(notifier, options)
+          end
+        end
+    end
+  end
 
   defmacro __using__(config) do
     quote location: :keep do
@@ -10,6 +29,28 @@ defmodule BoomNotifier do
 
       import BoomNotifier
       require Logger
+
+      settings = unquote(config)
+
+      try do
+        walkthrough_notifiers(
+          settings,
+          &if(function_exported?(&1, :validate!, 1)) do
+            &1.validate!(&2)
+          end
+        )
+      rescue
+        e ->
+          error_info = Exception.format_banner(:error, e, __STACKTRACE__)
+          [{module, function, arity, _}, {notifier, _, _, _} | _] = __STACKTRACE__
+          Exception.format_mfa(module, function, arity)
+
+          Logger.warn(
+            "Missing parameter: #{error_info} in #{
+              notifier |> to_string() |> String.split(".") |> List.last()
+            }"
+          )
+      end
 
       def handle_errors(conn, error) do
         {error_kind, error_info} = ErrorInfo.build(error, conn)
@@ -21,21 +62,7 @@ defmodule BoomNotifier do
 
           settings = unquote(config)
 
-          case Keyword.get(settings, :notifiers) do
-            nil ->
-              with {:ok, notifier} <- Keyword.fetch(settings, :notifier),
-                   {:ok, options} <- Keyword.fetch(settings, :options) do
-                notifier.notify(occurrences, options)
-              end
-
-            notifiers_config when is_list(notifiers_config) ->
-              for notifier_config <- notifiers_config do
-                with {:ok, notifier} <- Keyword.fetch(notifier_config, :notifier),
-                     {:ok, options} <- Keyword.fetch(notifier_config, :options) do
-                  notifier.notify(occurrences, options)
-                end
-              end
-          end
+          walkthrough_notifiers(settings, & &1.notify(occurrences, &2))
 
           {notification_trigger, _settings} =
             Keyword.pop(settings, :notification_trigger, :always)

--- a/lib/boom_notifier.ex
+++ b/lib/boom_notifier.ex
@@ -35,7 +35,7 @@ defmodule BoomNotifier do
       try do
         walkthrough_notifiers(
           settings,
-          &if(function_exported?(&1, :validate!, 1)) do
+          &if function_exported?(&1, :validate!, 1) do
             &1.validate!(&2)
           end
         )

--- a/lib/boom_notifier.ex
+++ b/lib/boom_notifier.ex
@@ -36,9 +36,11 @@ defmodule BoomNotifier do
         settings,
         &if function_exported?(&1, :validate_config, 1) do
           with {:error, message} <- &1.validate_config(&2) do
-            Logger.warn("Notifier option error: #{message} in #{
-              &1 |> to_string() |> String.split(".") |> List.last()
-            }")
+            Logger.warn(
+              "Notifier validation: #{message} in #{
+                &1 |> to_string() |> String.split(".") |> List.last()
+              }"
+            )
           end
         end
       )

--- a/lib/boom_notifier/error_storage.ex
+++ b/lib/boom_notifier/error_storage.ex
@@ -1,5 +1,6 @@
 defmodule BoomNotifier.ErrorStorage do
   @moduledoc false
+
   # Keeps track of the errors grouped by type and a counter so the notifier
   # knows the next time it should be executed
 

--- a/lib/boom_notifier/helpers.ex
+++ b/lib/boom_notifier/helpers.ex
@@ -1,5 +1,6 @@
 defmodule BoomNotifier.Helpers do
   @moduledoc false
+
   # Create basic info based on exception information
 
   def exception_basic_text(exception_name, controller, action) do

--- a/lib/boom_notifier/mail_notifier.ex
+++ b/lib/boom_notifier/mail_notifier.ex
@@ -33,16 +33,12 @@ defmodule BoomNotifier.MailNotifier do
 
   @impl BoomNotifier.Notifier
   def validate_config(options) do
-    with {:mailer, {:ok, _mailer}} <- {:mailer, Keyword.fetch(options, :mailer)},
-         {:from, {:ok, _from}} <- {:from, Keyword.fetch(options, :from)},
-         {:to, {:ok, _to}} <- {:to, Keyword.fetch(options, :to)},
-         {:subject, {:ok, _subject}} <- {:subject, Keyword.fetch(options, :subject)} do
-      :ok
-    else
-      {:mailer, :error} -> {:error, "Mailer is missing"}
-      {:from, :error} -> {:error, "From is missing"}
-      {:to, :error} -> {:error, "To is missing"}
-      {:subject, :error} -> {:error, "Subject is missing"}
+    missing_keys = Enum.reject([:mailer, :from, :to, :subject], &Keyword.has_key?(options, &1))
+
+    case missing_keys do
+      [] -> :ok
+      [missing_key] -> {:error, "#{inspect(missing_key)} parameter is missing"}
+      _ -> {:error, "The following parameters are missing: #{inspect(missing_keys)}"}
     end
   end
 

--- a/lib/boom_notifier/mail_notifier.ex
+++ b/lib/boom_notifier/mail_notifier.ex
@@ -33,10 +33,12 @@ defmodule BoomNotifier.MailNotifier do
 
   @impl BoomNotifier.Notifier
   def validate!(options) do
-    Keyword.fetch!(options, :mailer)
-    Keyword.fetch!(options, :from)
-    Keyword.fetch!(options, :to)
-    Keyword.fetch!(options, :subject)
+    with _mailer <- Keyword.fetch!(options, :mailer),
+         _from <- Keyword.fetch!(options, :from),
+         _to <- Keyword.fetch!(options, :to),
+         _subject <- Keyword.fetch!(options, :subject) do
+      nil
+    end
   end
 
   @impl BoomNotifier.Notifier

--- a/lib/boom_notifier/notifier.ex
+++ b/lib/boom_notifier/notifier.ex
@@ -4,4 +4,6 @@ defmodule BoomNotifier.Notifier do
   """
 
   @callback notify(list(%ErrorInfo{}), keyword(String.t())) :: no_return()
+  @callback validate!(keyword(String.t())) :: no_return()
+  @optional_callbacks validate!: 1
 end

--- a/lib/boom_notifier/notifier.ex
+++ b/lib/boom_notifier/notifier.ex
@@ -4,6 +4,6 @@ defmodule BoomNotifier.Notifier do
   """
 
   @callback notify(list(%ErrorInfo{}), keyword(String.t())) :: no_return()
-  @callback validate!(keyword(String.t())) :: no_return()
-  @optional_callbacks validate!: 1
+  @callback validate_config(keyword(String.t())) :: no_return()
+  @optional_callbacks validate_config: 1
 end

--- a/lib/boom_notifier/notifier.ex
+++ b/lib/boom_notifier/notifier.ex
@@ -4,6 +4,6 @@ defmodule BoomNotifier.Notifier do
   """
 
   @callback notify(list(%ErrorInfo{}), keyword(String.t())) :: no_return()
-  @callback validate_config(keyword(String.t())) :: no_return()
+  @callback validate_config(keyword(String.t())) :: :ok | {:error, String.t()}
   @optional_callbacks validate_config: 1
 end

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -24,8 +24,12 @@ defmodule BoomNotifier.WebhookNotifier do
   @type options :: [{:url, String.t()}]
 
   @impl BoomNotifier.Notifier
-  def validate!(options) do
-    Keyword.fetch!(options, :url)
+  def validate_config(options) do
+    with {:ok, _url} <- Keyword.fetch(options, :url) do
+      :ok
+    else
+      :error -> {:error, "Url is missing"}
+    end
   end
 
   @impl BoomNotifier.Notifier

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -24,6 +24,11 @@ defmodule BoomNotifier.WebhookNotifier do
   @type options :: [{:url, String.t()}]
 
   @impl BoomNotifier.Notifier
+  def validate!(options) do
+    Keyword.fetch!(options, :url)
+  end
+
+  @impl BoomNotifier.Notifier
   @spec notify(list(%ErrorInfo{}), options) :: no_return()
   def notify(errors_info, url: url) do
     payload =

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -25,10 +25,10 @@ defmodule BoomNotifier.WebhookNotifier do
 
   @impl BoomNotifier.Notifier
   def validate_config(options) do
-    with {:ok, _url} <- Keyword.fetch(options, :url) do
+    if Keyword.has_key?(options, :url) do
       :ok
     else
-      :error -> {:error, "Url is missing"}
+      {:error, ":url parameter is missing"}
     end
   end
 

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -198,20 +198,20 @@ defmodule MailerNotifierTest do
   end
 
   test "validates return {:error, message} when required params are not present" do
-    assert {:error, "Mailer is missing"} ==
+    assert {:error, "The following parameters are missing: [:mailer, :from, :to, :subject]"} ==
              BoomNotifier.MailNotifier.validate_config(random_param: nil)
 
-    assert {:error, "From is missing"} ==
+    assert {:error, "The following parameters are missing: [:from, :to, :subject]"} ==
              BoomNotifier.MailNotifier.validate_config(mailer: nil, random_param: nil)
 
-    assert {:error, "To is missing"} ==
+    assert {:error, "The following parameters are missing: [:to, :subject]"} ==
              BoomNotifier.MailNotifier.validate_config(
                mailer: nil,
                from: nil,
                random_param: nil
              )
 
-    assert {:error, "Subject is missing"} ==
+    assert {:error, ":subject parameter is missing"} ==
              BoomNotifier.MailNotifier.validate_config(
                mailer: nil,
                from: nil,

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -196,4 +196,31 @@ defmodule MailerNotifierTest do
         assert timestamp_line =~ ~r/Occurred on: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/
     end
   end
+
+  test "validates raises an exception when required params are not present" do
+    assert_raise KeyError, "key :mailer not found in: [random_param: nil]", fn ->
+      BoomNotifier.MailNotifier.validate!(random_param: nil)
+    end
+
+    assert_raise KeyError, "key :from not found in: [mailer: nil, random_param: nil]", fn ->
+      BoomNotifier.MailNotifier.validate!(mailer: nil, random_param: nil)
+    end
+
+    assert_raise KeyError,
+                 "key :to not found in: [mailer: nil, from: nil, random_param: nil]",
+                 fn ->
+                   BoomNotifier.MailNotifier.validate!(mailer: nil, from: nil, random_param: nil)
+                 end
+
+    assert_raise KeyError,
+                 "key :subject not found in: [mailer: nil, from: nil, to: nil, random_param: nil]",
+                 fn ->
+                   BoomNotifier.MailNotifier.validate!(
+                     mailer: nil,
+                     from: nil,
+                     to: nil,
+                     random_param: nil
+                   )
+                 end
+  end
 end

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -197,30 +197,26 @@ defmodule MailerNotifierTest do
     end
   end
 
-  test "validates raises an exception when required params are not present" do
-    assert_raise KeyError, "key :mailer not found in: [random_param: nil]", fn ->
-      BoomNotifier.MailNotifier.validate!(random_param: nil)
-    end
+  test "validates return {:error, message} when required params are not present" do
+    assert {:error, "Mailer is missing"} ==
+             BoomNotifier.MailNotifier.validate_config(random_param: nil)
 
-    assert_raise KeyError, "key :from not found in: [mailer: nil, random_param: nil]", fn ->
-      BoomNotifier.MailNotifier.validate!(mailer: nil, random_param: nil)
-    end
+    assert {:error, "From is missing"} ==
+             BoomNotifier.MailNotifier.validate_config(mailer: nil, random_param: nil)
 
-    assert_raise KeyError,
-                 "key :to not found in: [mailer: nil, from: nil, random_param: nil]",
-                 fn ->
-                   BoomNotifier.MailNotifier.validate!(mailer: nil, from: nil, random_param: nil)
-                 end
+    assert {:error, "To is missing"} ==
+             BoomNotifier.MailNotifier.validate_config(
+               mailer: nil,
+               from: nil,
+               random_param: nil
+             )
 
-    assert_raise KeyError,
-                 "key :subject not found in: [mailer: nil, from: nil, to: nil, random_param: nil]",
-                 fn ->
-                   BoomNotifier.MailNotifier.validate!(
-                     mailer: nil,
-                     from: nil,
-                     to: nil,
-                     random_param: nil
-                   )
-                 end
+    assert {:error, "Subject is missing"} ==
+             BoomNotifier.MailNotifier.validate_config(
+               mailer: nil,
+               from: nil,
+               to: nil,
+               random_param: nil
+             )
   end
 end

--- a/test/notifier_test.exs
+++ b/test/notifier_test.exs
@@ -282,11 +282,11 @@ defmodule NotifierTest do
     assert true
   end
 
-  test "logs when parameter is missing" do
+  test "logs when parameter in options is missing" do
     conn = conn(:get, "/")
 
     assert capture_log(fn ->
-             defmodule PlugErrorWithMissingParameterNotifier do
+             defmodule PlugLogWithMissingParameterNotifier do
                use BoomNotifier,
                  notifier: MissingParameterNotifier,
                  options: [
@@ -299,5 +299,38 @@ defmodule NotifierTest do
              end
            end) =~
              "Notifier validation: :parameter parameter is missing in MissingParameterNotifier"
+  end
+
+  test "logs when parameters in config are missing" do
+    conn = conn(:get, "/")
+
+    assert capture_log(fn ->
+             defmodule PlugLogWithMissingParameterNotifier do
+               use BoomNotifier, other: nil
+
+               def call(_conn, _opts) do
+                 raise TestException.exception([])
+               end
+             end
+           end) =~
+             "Settings error: The following parameters are missing: [:notifier, :options]"
+  end
+
+  test "logs when one parameter in config is missing" do
+    conn = conn(:get, "/")
+
+    assert capture_log(fn ->
+             defmodule PlugLogNotifierWithMissingParameterNotifier do
+               use BoomNotifier,
+                 options: [
+                   parameter: "value"
+                 ]
+
+               def call(_conn, _opts) do
+                 raise TestException.exception([])
+               end
+             end
+           end) =~
+             "Settings error: :notifier parameter missing"
   end
 end

--- a/test/notifier_test.exs
+++ b/test/notifier_test.exs
@@ -22,11 +22,6 @@ defmodule NotifierTest do
 
       send(self(), %{exception: %{subject: subject, body: body}})
     end
-
-    @impl BoomNotifier.Notifier
-    def validate!(options) do
-      Keyword.fetch!(options, :subject)
-    end
   end
 
   defmodule FailingNotifier do
@@ -47,8 +42,12 @@ defmodule NotifierTest do
     end
 
     @impl BoomNotifier.Notifier
-    def validate!(options) do
-      Keyword.fetch!(options, :parameter)
+    def validate_config(options) do
+      with {:ok, _parameter} <- Keyword.fetch(options, :url) do
+        :ok
+      else
+        :error -> {:error, "Parameter is missing"}
+      end
     end
   end
 
@@ -299,8 +298,7 @@ defmodule NotifierTest do
                end
              end
            end) =~
-             "Missing parameter: ** (KeyError) key :parameter not found in: [another_parameter: \"value\"]"
+             "Notifier option error: Parameter is missing in MissingParameterNotifier"
 
-    assert true
   end
 end

--- a/test/notifier_test.exs
+++ b/test/notifier_test.exs
@@ -43,10 +43,10 @@ defmodule NotifierTest do
 
     @impl BoomNotifier.Notifier
     def validate_config(options) do
-      with {:ok, _parameter} <- Keyword.fetch(options, :url) do
+      if Keyword.has_key?(options, :parameter) do
         :ok
       else
-        :error -> {:error, "Parameter is missing"}
+        {:error, ":parameter parameter is missing"}
       end
     end
   end
@@ -298,7 +298,6 @@ defmodule NotifierTest do
                end
              end
            end) =~
-             "Notifier option error: Parameter is missing in MissingParameterNotifier"
-
+             "Notifier validation: :parameter parameter is missing in MissingParameterNotifier"
   end
 end

--- a/test/notifier_test.exs
+++ b/test/notifier_test.exs
@@ -283,6 +283,8 @@ defmodule NotifierTest do
   end
 
   test "logs when parameter in options is missing" do
+    Code.compiler_options(ignore_module_conflict: true)
+
     conn = conn(:get, "/")
 
     assert capture_log(fn ->
@@ -299,9 +301,13 @@ defmodule NotifierTest do
              end
            end) =~
              "Notifier validation: :parameter parameter is missing in MissingParameterNotifier"
+
+    Code.compiler_options(ignore_module_conflict: false)
   end
 
   test "logs when parameters in config are missing" do
+    Code.compiler_options(ignore_module_conflict: true)
+
     conn = conn(:get, "/")
 
     assert capture_log(fn ->
@@ -314,6 +320,8 @@ defmodule NotifierTest do
              end
            end) =~
              "Settings error: The following parameters are missing: [:notifier, :options]"
+
+    Code.compiler_options(ignore_module_conflict: false)
   end
 
   test "logs when one parameter in config is missing" do

--- a/test/support/fake_mailer.ex
+++ b/test/support/fake_mailer.ex
@@ -1,5 +1,6 @@
 defmodule Support.FakeMailer do
   @moduledoc false
+
   # Overrides the `deliver_now` function.
   # Instead of sending an email it puts the fields in a mailbox so they can be
   # received in the test

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -57,10 +57,9 @@ defmodule WebhookNotifierTest do
     {:ok, bypass: bypass}
   end
 
-  test "validates raises an exception when url is not present" do
-    assert_raise KeyError, "key :url not found in: [random_param: nil]", fn ->
-      BoomNotifier.WebhookNotifier.validate!(random_param: nil)
-    end
+  test "validates return {:error, message} when url is not present" do
+    assert {:error, "Url is missing"} ==
+      BoomNotifier.WebhookNotifier.validate_config(random_param: nil)
   end
 
   test "request is sent to webhook", %{bypass: bypass} do

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -58,8 +58,8 @@ defmodule WebhookNotifierTest do
   end
 
   test "validates return {:error, message} when url is not present" do
-    assert {:error, "Url is missing"} ==
-      BoomNotifier.WebhookNotifier.validate_config(random_param: nil)
+    assert {:error, ":url parameter is missing"} ==
+             BoomNotifier.WebhookNotifier.validate_config(random_param: nil)
   end
 
   test "request is sent to webhook", %{bypass: bypass} do

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -57,6 +57,12 @@ defmodule WebhookNotifierTest do
     {:ok, bypass: bypass}
   end
 
+  test "validates raises an exception when url is not present" do
+    assert_raise KeyError, "key :url not found in: [random_param: nil]", fn ->
+      BoomNotifier.WebhookNotifier.validate!(random_param: nil)
+    end
+  end
+
   test "request is sent to webhook", %{bypass: bypass} do
     Bypass.expect(bypass, fn conn ->
       assert "POST" == conn.method


### PR DESCRIPTION
Fixes #17
- Add `validate!` to the notifier, raises an error in case one of the required keys for notification are not present

- Add the function `walkthrough_notifiers` to call a specific function in each notifier