### PR TITLE
Include custom data

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.7
+erlang 22.0

--- a/README.md
+++ b/README.md
@@ -263,7 +263,22 @@ Logger.metadata(name: "John")
 ### Using both
 
 You can do any combination of the above settings to include data
-from both sources.
+from both sources. The names of the fields are independent for each 
+source, they will appear under the source namespace.
+
+```elixir
+defmodule YourApp.Router do
+  use Phoenix.Router
+
+  use BoomNotifier,
+    custom_data: [
+      [assigns: [fields: [:current_user]]],
+      [logger: [fields: [:request_id, :current_user]]]
+    ],
+    notifiers: [
+      # ...
+    ]
+```
 
 ## License
 BoomNotifier is released under the terms of the [MIT License](https://github.com/wyeworks/boom/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -181,6 +181,91 @@ defmodule YourApp.Router do
     ]
 ```
 
+## Custom data
+By default, `BoomNotifier` will **not** include any custom data from your 
+requests.
+
+However, there are different strategies to decide which information do
+you want to include in the notifications using the `:custom_data` option 
+with one of the following values: `:assigns`, `:logger` or both.
+
+The included information will show up in your notification, in a new section 
+titled "Data".
+
+### Assigns
+This option will include the data that is in the [connection](https://hexdocs.pm/plug/Plug.Conn.html)
+`assigns` field.
+
+You can also specify the fields you want to retrieve from `conn.assigns`.
+
+```elixir
+defmodule YourApp.Router do
+  use Phoenix.Router
+
+  use BoomNotifier,
+    custom_data: :assigns,
+    notifiers: [
+      # ...
+    ]
+```
+
+```elixir
+defmodule YourApp.Router do
+  use Phoenix.Router
+
+  use BoomNotifier,
+    custom_data: [assigns: [fields: [:current_user, :session_data]]],
+    notifiers: [
+      # ...
+    ]
+```
+
+Example of adding custom data to the connection:
+
+```elixir
+conn
+|> assign(:name, "John")
+```
+
+### Logger
+This option will include the data that is in the [Logger](https://hexdocs.pm/logger/Logger.html)
+`metadata` field.
+
+You can also specify the fields you want to retrieve from `Logger.metadata()`.
+
+```elixir
+defmodule YourApp.Router do
+  use Phoenix.Router
+
+  use BoomNotifier,
+    custom_data: :logger,
+    notifiers: [
+      # ...
+    ]
+```
+
+```elixir
+defmodule YourApp.Router do
+  use Phoenix.Router
+
+  use BoomNotifier,
+    custom_data: [logger: [fields: [:request_id, :current_user]]],
+    notifiers: [
+      # ...
+    ]
+```
+
+Example of adding custom data to the logger:
+
+```elixir
+Logger.metadata(name: "John")
+```
+
+### Using both
+
+You can do any combination of the above settings to include data
+from both sources.
+
 ## License
 BoomNotifier is released under the terms of the [MIT License](https://github.com/wyeworks/boom/blob/master/LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ defmodule YourApp.Router do
     ]
 ```
 
-## Custom data
+## Custom data or Metadata
 By default, `BoomNotifier` will **not** include any custom data from your 
 requests.
 
@@ -190,7 +190,7 @@ you want to include in the notifications using the `:custom_data` option
 with one of the following values: `:assigns`, `:logger` or both.
 
 The included information will show up in your notification, in a new section 
-titled "Data".
+titled "Metadata".
 
 ### Assigns
 This option will include the data that is in the [connection](https://hexdocs.pm/plug/Plug.Conn.html)
@@ -223,8 +223,7 @@ defmodule YourApp.Router do
 Example of adding custom data to the connection:
 
 ```elixir
-conn
-|> assign(:name, "John")
+assign(conn, :name, "John")
 ```
 
 ### Logger

--- a/lib/boom_notifier/error_info.ex
+++ b/lib/boom_notifier/error_info.ex
@@ -18,39 +18,29 @@ defmodule ErrorInfo do
           map()
         ) :: {atom(), %ErrorInfo{}}
   def build(%{reason: reason, stack: stack} = error, conn) do
-    {get_reason(error), build_info(reason, stack, conn)}
-  end
+    {error_reason, error_name} = error_reason(reason)
 
-  defp build_info(%name{message: reason}, stack, conn) do
-    %{build_without_name(reason, stack, conn) | name: name}
-  end
-
-  defp build_info(%{message: reason}, stack, conn) do
-    %{build_without_name(reason, stack, conn) | name: "Error"}
-  end
-
-  defp build_info(reason, stack, conn) when is_binary(reason) do
-    build_info(%{message: reason}, stack, conn)
-  end
-
-  defp build_info(reason, stack, conn) do
-    build_info(%{message: inspect(reason)}, stack, conn)
-  end
-
-  defp get_reason(%{reason: %name{}}), do: name
-  defp get_reason(%{error: %{kind: kind}}), do: kind
-  defp get_reason(_), do: :error
-
-  defp build_without_name(reason, stack, conn) do
-    %ErrorInfo{
-      reason: reason,
+    error_info = %ErrorInfo{
+      reason: error_reason,
       stack: stack,
       controller: get_in(conn.private, [:phoenix_controller]),
       action: get_in(conn.private, [:phoenix_action]),
       request: build_request_info(conn),
-      timestamp: DateTime.utc_now()
+      timestamp: DateTime.utc_now(),
+      name: error_name,
     }
+
+    {error_type(error), error_info}
   end
+
+  defp error_reason(%name{message: reason}), do: {reason, name}
+  defp error_reason(%{message: reason}), do: {reason, "Error"}
+  defp error_reason(reason) when is_binary(reason), do: error_reason(%{message: reason})
+  defp error_reason(reason), do: error_reason(%{message: inspect(reason)})
+
+  defp error_type(%{reason: %name{}}), do: name
+  defp error_type(%{error: %{kind: kind}}), do: kind
+  defp error_type(_), do: :error
 
   defp build_request_info(conn) do
     %{
@@ -73,7 +63,7 @@ defmodule ErrorInfo do
       qs -> "#{base}?#{qs}"
     end
   end
-
+  
   # Credit: https://github.com/jarednorman/plugsnag/blob/master/lib/plugsnag/basic_error_report_builder.ex
   defp format_ip(ip) do
     ip

--- a/lib/boom_notifier/error_info.ex
+++ b/lib/boom_notifier/error_info.ex
@@ -7,7 +7,7 @@ defmodule ErrorInfo do
   # among other things) and custom data depending on the configuration.
 
   @enforce_keys [:reason, :stack, :timestamp]
-  defstruct [:name, :reason, :stack, :controller, :action, :request, :timestamp, :data]
+  defstruct [:name, :reason, :stack, :controller, :action, :request, :timestamp, :metadata]
 
   @type option ::
           :logger
@@ -36,7 +36,7 @@ defmodule ErrorInfo do
       request: build_request_info(conn),
       timestamp: DateTime.utc_now(),
       name: error_name,
-      data: build_custom_data(conn, custom_data_strategy)
+      metadata: build_custom_data(conn, custom_data_strategy)
     }
 
     {error_type(error), error_info}

--- a/lib/boom_notifier/error_info.ex
+++ b/lib/boom_notifier/error_info.ex
@@ -2,12 +2,19 @@ defmodule ErrorInfo do
   @moduledoc false
 
   # The ErrorInfo struct holds all the information about the exception.
-  # It includes the error message, the stacktrace and context information
+  # It includes the error message, the stacktrace, context information
   # (information about the request, the current controller and action,
-  # among other things).
+  # among other things) and custom data depending on the configuration.
 
   @enforce_keys [:reason, :stack, :timestamp]
-  defstruct [:name, :reason, :stack, :controller, :action, :request, :timestamp]
+  defstruct [:name, :reason, :stack, :controller, :action, :request, :timestamp, :data]
+
+  @type option ::
+          :logger
+          | [logger: [fields: list(atom())]]
+          | :assigns
+          | [assigns: [fields: list(atom())]]
+  @type custom_data_strategy_type :: :nothing | option | [option]
 
   @spec build(
           %{
@@ -15,9 +22,10 @@ defmodule ErrorInfo do
             required(:stack) => Exception.stacktrace(),
             optional(any()) => any()
           },
-          map()
+          map(),
+          custom_data_strategy_type
         ) :: {atom(), %ErrorInfo{}}
-  def build(%{reason: reason, stack: stack} = error, conn) do
+  def build(%{reason: reason, stack: stack} = error, conn, custom_data_strategy) do
     {error_reason, error_name} = error_reason(reason)
 
     error_info = %ErrorInfo{
@@ -28,6 +36,7 @@ defmodule ErrorInfo do
       request: build_request_info(conn),
       timestamp: DateTime.utc_now(),
       name: error_name,
+      data: build_custom_data(conn, custom_data_strategy)
     }
 
     {error_type(error), error_info}
@@ -63,11 +72,42 @@ defmodule ErrorInfo do
       qs -> "#{base}?#{qs}"
     end
   end
-  
+
   # Credit: https://github.com/jarednorman/plugsnag/blob/master/lib/plugsnag/basic_error_report_builder.ex
   defp format_ip(ip) do
     ip
     |> Tuple.to_list()
     |> Enum.join(".")
   end
+
+  @spec build_custom_data(map(), custom_data_strategy_type) :: map()
+  defp build_custom_data(_conn, :nothing), do: %{}
+
+  defp build_custom_data(_conn, :logger),
+    do: %{logger: Enum.into(Logger.metadata(), %{})}
+
+  defp build_custom_data(_conn, logger: [fields: field_names]),
+    do: %{
+      logger:
+        Enum.reduce(field_names, %{}, fn field_name, acc ->
+          Map.put(acc, field_name, Logger.metadata()[field_name])
+        end)
+    }
+
+  defp build_custom_data(conn, :assigns),
+    do: %{assigns: conn.assigns()}
+
+  defp build_custom_data(conn, assigns: [fields: field_names]),
+    do: %{
+      assigns:
+        Enum.reduce(field_names, %{}, fn field_name, acc ->
+          Map.put(acc, field_name, conn.assigns[field_name])
+        end)
+    }
+
+  defp build_custom_data(conn, options),
+    do:
+      Enum.reduce(options, %{}, fn opt, acc ->
+        Map.merge(acc, build_custom_data(conn, opt))
+      end)
 end

--- a/lib/boom_notifier/error_info.ex
+++ b/lib/boom_notifier/error_info.ex
@@ -81,7 +81,7 @@ defmodule ErrorInfo do
   end
 
   @spec build_custom_data(map(), custom_data_strategy_type) :: map()
-  defp build_custom_data(_conn, :nothing), do: %{}
+  defp build_custom_data(_conn, :nothing), do: nil
 
   defp build_custom_data(_conn, :logger),
     do: %{logger: Enum.into(Logger.metadata(), %{})}

--- a/lib/boom_notifier/mail_notifier/html_content.ex
+++ b/lib/boom_notifier/mail_notifier/html_content.ex
@@ -14,7 +14,7 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
         request: request,
         stack: stack,
         timestamp: timestamp,
-        data: data
+        metadata: metadata
       }) do
     exception_summary =
       if controller && action do
@@ -26,7 +26,7 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
       request: request,
       exception_stack_entries: Enum.map(stack, &entry_to_map/1),
       timestamp: format_timestamp(timestamp),
-      data: data
+      metadata: metadata
     }
   end
 

--- a/lib/boom_notifier/mail_notifier/html_content.ex
+++ b/lib/boom_notifier/mail_notifier/html_content.ex
@@ -13,7 +13,8 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
         action: action,
         request: request,
         stack: stack,
-        timestamp: timestamp
+        timestamp: timestamp,
+        data: data
       }) do
     exception_summary =
       if controller && action do
@@ -24,7 +25,8 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
       exception_summary: exception_summary,
       request: request,
       exception_stack_entries: Enum.map(stack, &entry_to_map/1),
-      timestamp: format_timestamp(timestamp)
+      timestamp: format_timestamp(timestamp),
+      data: data
     }
   end
 

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -12,9 +12,26 @@
       <li>Client IP: <%= error.request.client_ip %></li>
     </ul>
   <% end %>
+  <ul style="list-style-type: none;">
+    <li>Occurred on: <%= error.timestamp %></li>
+  </ul>
+  <%= if error.data do %>
     <ul style="list-style-type: none;">
-      <li>Occurred on: <%= error.timestamp %></li>
+      <li>
+        Data:
+        <ul style="list-style-type: none;">
+          <%= for {source, fields} <- error.data do %>
+            <%= source %>: 
+              <ul style="list-style-type: none;">
+                <%= for {k, v} <- fields do %>
+                  <li><%= k %>: <%= v %> </li>
+                <% end %>
+              </ul>
+          <% end %>
+        </ul>
+      </li>
     </ul>
+  <% end %>
   <ul style="list-style-type: none;">
     <%= for entry <- error.exception_stack_entries do %>
       <li>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -15,12 +15,12 @@
   <ul style="list-style-type: none;">
     <li>Occurred on: <%= error.timestamp %></li>
   </ul>
-  <%= if error.data do %>
+  <%= if error.metadata do %>
     <ul style="list-style-type: none;">
       <li>
-        Data:
+        Metadata:
         <ul style="list-style-type: none;">
-          <%= for {source, fields} <- error.data do %>
+          <%= for {source, fields} <- error.metadata do %>
             <%= source %>: 
               <ul style="list-style-type: none;">
                 <%= for {k, v} <- fields do %>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
@@ -13,9 +13,9 @@
       Client IP: <%= error.request.client_ip %>
   <% end %>
   Occurred on: <%= error.timestamp %>
-  <%= if error.data do %>
-    Data:
-    <%= for {source, fields} <- error.data do %>
+  <%= if error.metadata do %>
+    Metadata:
+    <%= for {source, fields} <- error.metadata do %>
       <%= source %>: 
         <%= for {k, v} <- fields do %>
           <%= k %>: <%= v %> 

--- a/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
@@ -4,15 +4,24 @@
   <% end %>
   <%= if error.request do %>
     Request Information:
-    URL: <%= error.request.url %>
-    Path: <%= error.request.path %>
-    Method: <%= error.request.method %>
-    Port: <%= error.request.port %>
-    Scheme: <%= error.request.scheme %>
-    Query String: <%= error.request.query_string %>
-    Client IP: <%= error.request.client_ip %>
+      URL: <%= error.request.url %>
+      Path: <%= error.request.path %>
+      Method: <%= error.request.method %>
+      Port: <%= error.request.port %>
+      Scheme: <%= error.request.scheme %>
+      Query String: <%= error.request.query_string %>
+      Client IP: <%= error.request.client_ip %>
   <% end %>
-    Occurred on: <%= error.timestamp %>
+  Occurred on: <%= error.timestamp %>
+  <%= if error.data do %>
+    Data:
+    <%= for {source, fields} <- error.data do %>
+      <%= source %>: 
+        <%= for {k, v} <- fields do %>
+          <%= k %>: <%= v %> 
+        <% end %>
+    <% end %>
+  <% end %>
   <%= for entry <- error.exception_stack_entries do %>
     <%= entry %>
   <% end %>

--- a/lib/boom_notifier/mail_notifier/text_content.ex
+++ b/lib/boom_notifier/mail_notifier/text_content.ex
@@ -13,7 +13,8 @@ defmodule BoomNotifier.MailNotifier.TextContent do
         action: action,
         request: request,
         stack: stack,
-        timestamp: timestamp
+        timestamp: timestamp,
+        data: data
       }) do
     exception_summary =
       if controller && action do
@@ -24,7 +25,8 @@ defmodule BoomNotifier.MailNotifier.TextContent do
       exception_summary: exception_summary,
       request: request,
       exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
-      timestamp: format_timestamp(timestamp)
+      timestamp: format_timestamp(timestamp),
+      data: data
     }
   end
 

--- a/lib/boom_notifier/mail_notifier/text_content.ex
+++ b/lib/boom_notifier/mail_notifier/text_content.ex
@@ -14,7 +14,7 @@ defmodule BoomNotifier.MailNotifier.TextContent do
         request: request,
         stack: stack,
         timestamp: timestamp,
-        data: data
+        metadata: metadata
       }) do
     exception_summary =
       if controller && action do
@@ -26,7 +26,7 @@ defmodule BoomNotifier.MailNotifier.TextContent do
       request: request,
       exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
       timestamp: format_timestamp(timestamp),
-      data: data
+      metadata: metadata
     }
   end
 

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -54,7 +54,7 @@ defmodule BoomNotifier.WebhookNotifier do
          request: request,
          stack: stack,
          timestamp: timestamp,
-         data: data
+         metadata: metadata
        }) do
     exception_summary =
       if controller && action do
@@ -66,7 +66,7 @@ defmodule BoomNotifier.WebhookNotifier do
       request: request,
       exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
       timestamp: DateTime.to_iso8601(timestamp),
-      data: data
+      metadata: metadata
     }
   end
 end

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -53,7 +53,8 @@ defmodule BoomNotifier.WebhookNotifier do
          action: action,
          request: request,
          stack: stack,
-         timestamp: timestamp
+         timestamp: timestamp,
+         data: data
        }) do
     exception_summary =
       if controller && action do
@@ -64,7 +65,8 @@ defmodule BoomNotifier.WebhookNotifier do
       exception_summary: exception_summary,
       request: request,
       exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
-      timestamp: DateTime.to_iso8601(timestamp)
+      timestamp: DateTime.to_iso8601(timestamp),
+      data: data
     }
   end
 end

--- a/test/error_info_test.exs
+++ b/test/error_info_test.exs
@@ -246,4 +246,16 @@ defmodule ErrorInfoTest do
 
     assert %{assigns: %{name: "Davis"}, logger: %{age: 17}} = metadata
   end
+
+  test "Error info metadata includes filtered equal fields for assigns and logger" do
+    %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
+
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
+      ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, [
+        [assigns: [fields: [:name]]],
+        [logger: [fields: [:name]]]
+      ])
+
+    assert %{assigns: %{name: "Davis"}, logger: %{name: "Dennis"}} = metadata
+  end
 end

--- a/test/error_info_test.exs
+++ b/test/error_info_test.exs
@@ -171,7 +171,16 @@ defmodule ErrorInfoTest do
     assert DateTime.diff(DateTime.utc_now(), timestamp, :second) <= 1
   end
 
-  test "Error info includes assigns" do
+  test "Error info data is nil when strategy is :nothing" do
+    %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
+
+    {_error_kind, %ErrorInfo{data: data}} =
+      ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :nothing)
+
+    assert nil == data
+  end
+
+  test "Error info data includes assigns" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
     {_error_kind, %ErrorInfo{data: data}} =
@@ -180,7 +189,7 @@ defmodule ErrorInfoTest do
     assert %{assigns: %{age: 32, name: "Davis"}} = data
   end
 
-  test "Error info includes filtered fields for assigns" do
+  test "Error info data includes filtered fields for assigns" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
     {_error_kind, %ErrorInfo{data: data}} =
@@ -191,7 +200,7 @@ defmodule ErrorInfoTest do
     assert %{assigns: %{name: "Davis"}} = data
   end
 
-  test "Error info includes logger" do
+  test "Error info data includes logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
     {_error_kind, %ErrorInfo{data: data}} =
@@ -200,7 +209,7 @@ defmodule ErrorInfoTest do
     assert %{logger: %{age: 17, name: "Dennis"}} = data
   end
 
-  test "Error info includes filtered fields for logger" do
+  test "Error info data includes filtered fields for logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
     {_error_kind, %ErrorInfo{data: data}} =
@@ -211,7 +220,7 @@ defmodule ErrorInfoTest do
     assert %{logger: %{name: "Dennis"}} = data
   end
 
-  test "Error info includes assigns and logger" do
+  test "Error info data includes assigns and logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
     {_error_kind, %ErrorInfo{data: data}} =
@@ -226,7 +235,7 @@ defmodule ErrorInfoTest do
            } = data
   end
 
-  test "Error info includes filtered fields for assigns and logger" do
+  test "Error info data includes filtered fields for assigns and logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
     {_error_kind, %ErrorInfo{data: data}} =

--- a/test/error_info_test.exs
+++ b/test/error_info_test.exs
@@ -171,59 +171,59 @@ defmodule ErrorInfoTest do
     assert DateTime.diff(DateTime.utc_now(), timestamp, :second) <= 1
   end
 
-  test "Error info data is nil when strategy is :nothing" do
+  test "Error info metadata is nil when strategy is :nothing" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{data: data}} =
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :nothing)
 
-    assert nil == data
+    assert nil == metadata
   end
 
-  test "Error info data includes assigns" do
+  test "Error info metadata includes assigns" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{data: data}} =
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :assigns)
 
-    assert %{assigns: %{age: 32, name: "Davis"}} = data
+    assert %{assigns: %{age: 32, name: "Davis"}} = metadata
   end
 
-  test "Error info data includes filtered fields for assigns" do
+  test "Error info metadata includes filtered fields for assigns" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{data: data}} =
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn,
         assigns: [fields: [:name]]
       )
 
-    assert %{assigns: %{name: "Davis"}} = data
+    assert %{assigns: %{name: "Davis"}} = metadata
   end
 
-  test "Error info data includes logger" do
+  test "Error info metadata includes logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{data: data}} =
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :logger)
 
-    assert %{logger: %{age: 17, name: "Dennis"}} = data
+    assert %{logger: %{age: 17, name: "Dennis"}} = metadata
   end
 
-  test "Error info data includes filtered fields for logger" do
+  test "Error info metadata includes filtered fields for logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{data: data}} =
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn,
         logger: [fields: [:name]]
       )
 
-    assert %{logger: %{name: "Dennis"}} = data
+    assert %{logger: %{name: "Dennis"}} = metadata
   end
 
-  test "Error info data includes assigns and logger" do
+  test "Error info metadata includes assigns and logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{data: data}} =
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, [
         :assigns,
         :logger
@@ -232,18 +232,18 @@ defmodule ErrorInfoTest do
     assert %{
              assigns: %{age: 32, name: "Davis"},
              logger: %{age: 17, name: "Dennis"}
-           } = data
+           } = metadata
   end
 
-  test "Error info data includes filtered fields for assigns and logger" do
+  test "Error info metadata includes filtered fields for assigns and logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{data: data}} =
+    {_error_kind, %ErrorInfo{metadata: metadata}} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, [
         [assigns: [fields: [:name]]],
         [logger: [fields: [:age]]]
       ])
 
-    assert %{assigns: %{name: "Davis"}, logger: %{age: 17}} = data
+    assert %{assigns: %{name: "Davis"}, logger: %{age: 17}} = metadata
   end
 end

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -241,7 +241,7 @@ defmodule MailerNotifierTest do
         custom_data_info = Enum.slice(body, 10..16)
 
         assert [
-                 "Data:",
+                 "Metadata:",
                  "assigns:",
                  "age: 32",
                  "name: Davis",

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -28,16 +28,28 @@ defmodule MailerNotifierTest do
         from: "me@example.com",
         to: "foo@example.com",
         subject: "BOOM error caught"
-      ]
+      ],
+      custom_data: [:assigns, :logger]
 
     pipeline :browser do
       plug(:accepts, ["html"])
+      plug(:save_custom_data)
     end
 
     scope "/" do
       pipe_through(:browser)
       get("/", TestController, :index)
     end
+
+    def save_custom_data(conn, _) do
+      conn
+      |> assign(:name, "Davis")
+      |> assign(:age, 32)
+    end
+  end
+
+  setup do
+    Logger.metadata(name: "Dennis", age: 17)
   end
 
   test "Raising an error on failure" do
@@ -136,7 +148,7 @@ defmodule MailerNotifierTest do
 
     receive do
       {:email_text_body, body} ->
-        first_stack_line = Enum.at(body, 10)
+        first_stack_line = Enum.at(body, 17)
 
         assert "test/mailer_notifier_test.exs:" <>
                  <<name::binary-size(2), ": MailerNotifierTest.TestController.index/2">> =
@@ -152,7 +164,7 @@ defmodule MailerNotifierTest do
       {:email_html_body, body} ->
         [stacktrace_list | _] =
           Regex.scan(~r/<ul.+?>(.)+?<\/ul>/s, body)
-          |> Enum.at(2)
+          |> Enum.at(4)
 
         [first_stack_line | _] =
           Regex.scan(~r/<li>(.)+?<\/li>/s, stacktrace_list)
@@ -218,5 +230,45 @@ defmodule MailerNotifierTest do
                to: nil,
                random_param: nil
              )
+  end
+
+  test "Custom data appears in email text body" do
+    conn = conn(:get, "/")
+    catch_error(TestRouter.call(conn, []))
+
+    receive do
+      {:email_text_body, body} ->
+        custom_data_info = Enum.slice(body, 10..16)
+
+        assert [
+                 "Data:",
+                 "assigns:",
+                 "age: 32",
+                 "name: Davis",
+                 "logger:",
+                 "age: 17",
+                 "name: Dennis"
+               ] = custom_data_info
+    end
+  end
+
+  test "Custom data appears in email HTML body" do
+    conn = conn(:get, "/")
+    catch_error(TestRouter.call(conn, []))
+
+    receive do
+      {:email_html_body, body} ->
+        custom_data_info =
+          Regex.scan(~r/<li>(.)+?<\/li>/, body)
+          |> Enum.map(&Enum.at(&1, 0))
+          |> Enum.slice(9..13)
+
+        assert [
+                 "<li>age: 32 </li>",
+                 "<li>name: Davis </li>",
+                 "<li>age: 17 </li>",
+                 "<li>name: Dennis </li>"
+               ] = custom_data_info
+    end
   end
 end

--- a/test/notifier_test.exs
+++ b/test/notifier_test.exs
@@ -318,8 +318,7 @@ defmodule NotifierTest do
                  raise TestException.exception([])
                end
              end
-           end) =~
-             "Settings error: The following parameters are missing: [:notifier, :options]"
+           end) =~ "Settings error: The following parameters are missing: [:notifier, :options]"
 
     Code.compiler_options(ignore_module_conflict: false)
   end
@@ -338,7 +337,6 @@ defmodule NotifierTest do
                  raise TestException.exception([])
                end
              end
-           end) =~
-             "Settings error: :notifier parameter missing"
+           end) =~ "Settings error: :notifier parameter missing"
   end
 end

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -19,7 +19,7 @@ defmodule WebhookNotifierTest do
       scheme: "http",
       url: "http://www.example.com/"
     },
-    data: %{
+    metadata: %{
       assigns: %{
         name: "Davis",
         age: 32
@@ -92,7 +92,7 @@ defmodule WebhookNotifierTest do
           exception_stack_entries: [first_stack_entry | _] = exception_stack_entries,
           request: request,
           timestamp: timestamp,
-          data: data
+          metadata: metadata
         }
       ] = Jason.decode!(body, keys: :atoms)
 
@@ -102,7 +102,7 @@ defmodule WebhookNotifierTest do
       assert first_stack_entry =~ "WebhookNotifierTest.TestController.index/2"
 
       assert request == @expected_response.request
-      assert data == @expected_response.data
+      assert metadata == @expected_response.metadata
 
       {:ok, timestamp, _utc_offset} = DateTime.from_iso8601(timestamp)
       assert DateTime.diff(timestamp, DateTime.utc_now(), :second) <= 1

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -18,6 +18,16 @@ defmodule WebhookNotifierTest do
       query_string: "",
       scheme: "http",
       url: "http://www.example.com/"
+    },
+    data: %{
+      assigns: %{
+        name: "Davis",
+        age: 32
+      },
+      logger: %{
+        name: "Dennis",
+        age: 17
+      }
     }
   }
 
@@ -40,19 +50,28 @@ defmodule WebhookNotifierTest do
 
     use BoomNotifier,
       notifier: BoomNotifier.WebhookNotifier,
-      options: [url: "http://localhost:1234"]
+      options: [url: "http://localhost:1234"],
+      custom_data: [:assigns, :logger]
 
     pipeline :browser do
       plug(:accepts, ["html"])
+      plug(:save_custom_data)
     end
 
     scope "/" do
       pipe_through(:browser)
       get("/", TestController, :index)
     end
+
+    def save_custom_data(conn, _) do
+      conn
+      |> assign(:name, "Davis")
+      |> assign(:age, 32)
+    end
   end
 
   setup do
+    Logger.metadata(name: "Dennis", age: 17)
     bypass = Bypass.open(port: 1234)
     {:ok, bypass: bypass}
   end
@@ -72,7 +91,8 @@ defmodule WebhookNotifierTest do
           exception_summary: exception_summary,
           exception_stack_entries: [first_stack_entry | _] = exception_stack_entries,
           request: request,
-          timestamp: timestamp
+          timestamp: timestamp,
+          data: data
         }
       ] = Jason.decode!(body, keys: :atoms)
 
@@ -82,6 +102,7 @@ defmodule WebhookNotifierTest do
       assert first_stack_entry =~ "WebhookNotifierTest.TestController.index/2"
 
       assert request == @expected_response.request
+      assert data == @expected_response.data
 
       {:ok, timestamp, _utc_offset} = DateTime.from_iso8601(timestamp)
       assert DateTime.diff(timestamp, DateTime.utc_now(), :second) <= 1


### PR DESCRIPTION
Closes https://github.com/wyeworks/boom/issues/19

This PR implements the ability to include custom data from the connection `assigns` or Logger `metadata` in the exception.

Possible configurations are described in README. Feel free to comment any other idea of how to model them.

Output example:
![Screenshot at May 26 11-20-56](https://user-images.githubusercontent.com/42446726/119716497-9067c600-be3b-11eb-9dbb-a65f8354e7d4.png)

This PR also
- Add `.tool-versions` file. Maybe it's not necessary, but I needed specific versions to get everything up and running.
- Refactor `error_info` module to make easier to add new fields to the struct.