### PR TITLE
Show link as simple text

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,4 +185,4 @@ defmodule YourApp.Router do
 BoomNotifier is released under the terms of the [MIT License](https://github.com/wyeworks/boom/blob/master/LICENSE).
 
 ## Credits
-The authors of this project are [Ignacio](https://github.com/iaguirre88) and [Jorge](https://github.com/jmbejar). It is sponsored and maintained by [<img src="https://www.wyeworks.com/images/logo-wbg.svg"/>](https://www.wyeworks.com)
+The authors of this project are [Ignacio](https://github.com/iaguirre88) and [Jorge](https://github.com/jmbejar). It is sponsored and maintained by [Wyeworks](https://www.wyeworks.com).


### PR DESCRIPTION
Closes #38 

This just removes the Wyeworks image and uses simple text for the link. The reason is that the link as an image is not correctly displayed on hexdocs and it seems to be an issue on ex_doc or more precisely one of its dependencies: https://github.com/elixir-lang/ex_doc/issues/668