### PR TITLE
Fix warning 'warning: variable name is unused'

### DIFF
--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -151,7 +151,7 @@ defmodule MailerNotifierTest do
         first_stack_line = Enum.at(body, 17)
 
         assert "test/mailer_notifier_test.exs:" <>
-                 <<name::binary-size(2), ": MailerNotifierTest.TestController.index/2">> =
+                 <<_name::binary-size(2), ": MailerNotifierTest.TestController.index/2">> =
                  first_stack_line
     end
   end

--- a/test/notifier_test.exs
+++ b/test/notifier_test.exs
@@ -173,7 +173,7 @@ defmodule NotifierTest do
         body: [
           [
             "test/notifier_test.exs:" <>
-              <<name::binary-size(2),
+              <<_name::binary-size(2),
                 ": NotifierTest.PlugErrorWithSingleNotifier.\"call \(overridable 1\)\"/2\n">>
             | _
           ]
@@ -192,7 +192,7 @@ defmodule NotifierTest do
         body: [
           [
             "test/notifier_test.exs:" <>
-              <<name::binary-size(2),
+              <<_name::binary-size(2),
                 ": NotifierTest.PlugErrorWithMultipleNotifiers.\"call \(overridable 1\)\"/2\n">>
             | _
           ]


### PR DESCRIPTION
Seen when running `mix test`.