### PR TITLE
Fix 'Supervisor.Spec.supervisor/2 is deprecated' warning

### DIFF
--- a/lib/boom_notifier/application.ex
+++ b/lib/boom_notifier/application.ex
@@ -4,10 +4,15 @@ defmodule BoomNotifier.Application do
   @moduledoc false
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      supervisor(BoomNotifier.ErrorStorage, []),
+      {
+        BoomNotifier.ErrorStorage,
+        {BoomNotifier.ErrorStorage, :start_link, []},
+        :permanent,
+        :infinity,
+        :supervisor,
+        [BoomNotifier.ErrorStorage]
+      },
       BoomNotifier.NotifierSenderServer
     ]
 

--- a/lib/boom_notifier/application.ex
+++ b/lib/boom_notifier/application.ex
@@ -8,7 +8,6 @@ defmodule BoomNotifier.Application do
       %{
         id: BoomNotifier.ErrorStorage,
         start: {BoomNotifier.ErrorStorage, :start_link, []},
-        restart: :permanent,
         type: :supervisor,
         modules: [BoomNotifier.ErrorStorage]
       },

--- a/lib/boom_notifier/application.ex
+++ b/lib/boom_notifier/application.ex
@@ -5,13 +5,13 @@ defmodule BoomNotifier.Application do
 
   def start(_type, _args) do
     children = [
-      {
-        BoomNotifier.ErrorStorage,
-        {BoomNotifier.ErrorStorage, :start_link, []},
-        :permanent,
-        :infinity,
-        :supervisor,
-        [BoomNotifier.ErrorStorage]
+      %{
+        id: BoomNotifier.ErrorStorage,
+        start: {BoomNotifier.ErrorStorage, :start_link, []},
+        restart: :permanent,
+        shutdown: :infinity,
+        type: :supervisor,
+        modules: [BoomNotifier.ErrorStorage]
       },
       BoomNotifier.NotifierSenderServer
     ]

--- a/lib/boom_notifier/application.ex
+++ b/lib/boom_notifier/application.ex
@@ -9,7 +9,6 @@ defmodule BoomNotifier.Application do
         id: BoomNotifier.ErrorStorage,
         start: {BoomNotifier.ErrorStorage, :start_link, []},
         restart: :permanent,
-        shutdown: :infinity,
         type: :supervisor,
         modules: [BoomNotifier.ErrorStorage]
       },

--- a/lib/boom_notifier/application.ex
+++ b/lib/boom_notifier/application.ex
@@ -8,8 +8,7 @@ defmodule BoomNotifier.Application do
       %{
         id: BoomNotifier.ErrorStorage,
         start: {BoomNotifier.ErrorStorage, :start_link, []},
-        type: :supervisor,
-        modules: [BoomNotifier.ErrorStorage]
+        type: :supervisor
       },
       BoomNotifier.NotifierSenderServer
     ]

--- a/lib/boom_notifier/application.ex
+++ b/lib/boom_notifier/application.ex
@@ -5,11 +5,7 @@ defmodule BoomNotifier.Application do
 
   def start(_type, _args) do
     children = [
-      %{
-        id: BoomNotifier.ErrorStorage,
-        start: {BoomNotifier.ErrorStorage, :start_link, []},
-        type: :supervisor
-      },
+      BoomNotifier.ErrorStorage,
       BoomNotifier.NotifierSenderServer
     ]
 

--- a/lib/boom_notifier/error_storage.ex
+++ b/lib/boom_notifier/error_storage.ex
@@ -4,7 +4,7 @@ defmodule BoomNotifier.ErrorStorage do
   # Keeps track of the errors grouped by type and a counter so the notifier
   # knows the next time it should be executed
 
-  use Agent
+  use Agent, start: {__MODULE__, :start_link, []}, type: :supervisor
 
   @spec start_link() :: Agent.on_start()
   def start_link do


### PR DESCRIPTION
### Before

```
$ mix compile
Compiling 2 files (.ex)
warning: Supervisor.Spec.supervisor/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/boom_notifier/application.ex:10: BoomNotifier.Application.start/2
```

### After

```
$ mix compile
Compiling 2 files (.ex)
```