### PR TITLE
No longer start ErrorStorage as a supervisor process

### DIFF
--- a/lib/boom_notifier/error_storage.ex
+++ b/lib/boom_notifier/error_storage.ex
@@ -4,7 +4,7 @@ defmodule BoomNotifier.ErrorStorage do
   # Keeps track of the errors grouped by type and a counter so the notifier
   # knows the next time it should be executed
 
-  use Agent, start: {__MODULE__, :start_link, []}, type: :supervisor
+  use Agent, start: {__MODULE__, :start_link, []}
 
   @spec start_link() :: Agent.on_start()
   def start_link do


### PR DESCRIPTION
Worker type is enough for it's purpose

This also changes behind the scenes the `shutdown` setting from `:infinity` to `5000`
which is the default for workers and OK for this process purpose

Addresses https://github.com/wyeworks/boom/pull/47#discussion_r690731323