### PR TITLE
Change stacktracke formatting for html emails

### DIFF
--- a/lib/boom_notifier/mail_notifier/html_content.ex
+++ b/lib/boom_notifier/mail_notifier/html_content.ex
@@ -24,7 +24,7 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
     %{
       exception_summary: exception_summary,
       request: request,
-      exception_stack_entries: Enum.map(stack, &entry_to_map/1),
+      exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
       timestamp: format_timestamp(timestamp),
       metadata: metadata
     }
@@ -33,18 +33,6 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
   defp template_path do
     current_folder_path = Path.dirname(__ENV__.file)
     Path.join([current_folder_path, "templates", "email_body.html.eex"])
-  end
-
-  defp entry_to_map(entry) do
-    {module, function, arity, [file: file, line: line]} = entry
-
-    %{
-      module: module,
-      function: function,
-      arity: arity,
-      file: file,
-      line: line
-    }
   end
 
   defp format_timestamp(timestamp) do

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -34,10 +34,7 @@
   <% end %>
   <ul style="list-style-type: none;">
     <%= for entry <- error.exception_stack_entries do %>
-      <li>
-        <span><%= entry.file %>:<%= entry.line %></span>
-        <span style=\"float: right\"><%= entry.module %>.<%= entry.function %>/<%= entry.arity %></span>
-      </li>
+      <li><%= entry %></li>
     <% end %>
   </ul>
   <hr>

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -175,21 +175,17 @@ defmodule MailerNotifierTest do
           Regex.scan(~r/<ul.+?>(.)+?<\/ul>/s, body)
           |> Enum.at(4)
 
-        stacktrace_list =
+        [first_stack_line | stacktrace_list] =
           Regex.scan(~r/<li>(.)+?<\/li>/s, stacktrace_list)
           |> Enum.map(&Enum.at(&1, 0))
 
-        assert [
-                 "<li>test/mailer_notifier_test.exs:18: MailerNotifierTest.TestController.index/2</li>",
-                 "<li>test/mailer_notifier_test.exs:9: MailerNotifierTest.TestController.action/2</li>",
-                 "<li>test/mailer_notifier_test.exs:9: MailerNotifierTest.TestController.phoenix_controller_pipeline/2</li>",
-                 "<li>(phoenix 1.5.10) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2</li>",
-                 "<li>lib/plug/error_handler.ex:80: MailerNotifierTest.TestRouter.call/2</li>",
-                 "<li>test/mailer_notifier_test.exs:170: MailerNotifierTest.\"test Exception stacktrace appears in email HTML body\"/1</li>",
-                 "<li>(ex_unit 1.12.2) lib/ex_unit/runner.ex:502: ExUnit.Runner.exec_test/1</li>",
-                 "<li>(stdlib 3.15.2) timer.erl:166: :timer.tc/1</li>",
-                 "<li>(ex_unit 1.12.2) lib/ex_unit/runner.ex:453: anonymous fn/4 in ExUnit.Runner.spawn_test_monitor/4</li>"
-               ] = stacktrace_list
+        [second_stack_line | _] = stacktrace_list
+
+        assert "<li>test/mailer_notifier_test.exs:18: MailerNotifierTest.TestController.index/2</li>" =
+                 first_stack_line
+
+        assert "<li>test/mailer_notifier_test.exs:9: MailerNotifierTest.TestController.action/2</li>" =
+                 second_stack_line
     end
   end
 

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -175,16 +175,21 @@ defmodule MailerNotifierTest do
           Regex.scan(~r/<ul.+?>(.)+?<\/ul>/s, body)
           |> Enum.at(4)
 
-        [first_stack_line | _] =
+        stacktrace_list =
           Regex.scan(~r/<li>(.)+?<\/li>/s, stacktrace_list)
           |> Enum.map(&Enum.at(&1, 0))
 
-        [file, exception] =
-          Regex.scan(~r/<span.*>(.+)<\/span>/, first_stack_line)
-          |> Enum.map(&Enum.at(&1, 1))
-
-        assert "test/mailer_notifier_test.exs:18" = file
-        assert "Elixir.MailerNotifierTest.TestController.index/2" = exception
+        assert [
+                 "<li>test/mailer_notifier_test.exs:18: MailerNotifierTest.TestController.index/2</li>",
+                 "<li>test/mailer_notifier_test.exs:9: MailerNotifierTest.TestController.action/2</li>",
+                 "<li>test/mailer_notifier_test.exs:9: MailerNotifierTest.TestController.phoenix_controller_pipeline/2</li>",
+                 "<li>(phoenix 1.5.10) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2</li>",
+                 "<li>lib/plug/error_handler.ex:80: MailerNotifierTest.TestRouter.call/2</li>",
+                 "<li>test/mailer_notifier_test.exs:170: MailerNotifierTest.\"test Exception stacktrace appears in email HTML body\"/1</li>",
+                 "<li>(ex_unit 1.12.2) lib/ex_unit/runner.ex:502: ExUnit.Runner.exec_test/1</li>",
+                 "<li>(stdlib 3.15.2) timer.erl:166: :timer.tc/1</li>",
+                 "<li>(ex_unit 1.12.2) lib/ex_unit/runner.ex:453: anonymous fn/4 in ExUnit.Runner.spawn_test_monitor/4</li>"
+               ] = stacktrace_list
     end
   end
 
@@ -270,7 +275,7 @@ defmodule MailerNotifierTest do
         custom_data_info =
           Regex.scan(~r/<li>(.)+?<\/li>/, body)
           |> Enum.map(&Enum.at(&1, 0))
-          |> Enum.slice(9..13)
+          |> Enum.slice(9..12)
 
         assert [
                  "<li>age: 32 </li>",


### PR DESCRIPTION
Closes https://github.com/wyeworks/boom/issues/46.

With this change the emails in html format will send the stack trace formatted by https://hexdocs.pm/elixir/1.12/Exception.html#format_stacktrace_entry/1, as we do for emails in text format.