### PR TITLE
Avoids repetitive and noisy route dispatch log output in test

### DIFF
--- a/test/error_info_test.exs
+++ b/test/error_info_test.exs
@@ -49,9 +49,9 @@ defmodule ErrorInfoTest do
 
     scope "/" do
       pipe_through(:browser)
-      Phoenix.Router.get("/", TestController, :index)
-      Phoenix.Router.post("/create", TestController, :create)
-      Phoenix.Router.get("/nil_access", TestController, :nil_access)
+      Phoenix.Router.get("/", TestController, :index, log: false)
+      Phoenix.Router.post("/create", TestController, :create, log: false)
+      Phoenix.Router.get("/nil_access", TestController, :nil_access, log: false)
     end
 
     def save_custom_data(conn, _) do

--- a/test/mailer_notifier_test.exs
+++ b/test/mailer_notifier_test.exs
@@ -40,7 +40,7 @@ defmodule MailerNotifierTest do
 
     scope "/" do
       pipe_through(:browser)
-      get("/", TestController, :index)
+      get("/", TestController, :index, log: false)
     end
 
     def save_custom_data(conn, _) do

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -60,7 +60,7 @@ defmodule WebhookNotifierTest do
 
     scope "/" do
       pipe_through(:browser)
-      get("/", TestController, :index)
+      get("/", TestController, :index, log: false)
     end
 
     def save_custom_data(conn, _) do


### PR DESCRIPTION
### Before

```
$ mix test
warning: Phoenix now requires you to explicitly list which engine to use
for Phoenix JSON encoding. We recommend everyone to upgrade to
Jason by setting in your config/config.exs:

    config :phoenix, :json_library, Jason

And then adding {:jason, "~> 1.0"} as a dependency.

If instead you would rather continue using Poison, then add to
your config/config.exs:

    config :phoenix, :json_library, Poison

  (phoenix 1.5.10) lib/phoenix.ex:38: Phoenix.start/2
  (kernel 8.0.1) application_master.erl:293: :application_master.start_it_old/4

...........
15:21:57.738 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.744 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.744 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.744 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.744 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.744 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.745 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]

15:21:57.745 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]

15:21:57.745 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.745 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
...
15:21:57.745 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.745 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.746 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.746 [debug] Processing with ErrorInfoTest.TestController.nil_access/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.751 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.751 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.751 [debug] Processing with ErrorInfoTest.TestController.create/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.752 [debug] Processing with ErrorInfoTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
..............
15:21:57.962 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.963 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.964 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.966 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.967 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.967 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.968 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
..
15:21:57.969 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.970 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.971 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.971 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.972 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.
15:21:57.973 [debug] Processing with MailerNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
..
15:21:57.987 [debug] Processing with WebhookNotifierTest.TestController.index/2
  Parameters: [UNFETCHED]
  Pipelines: [:browser]
.

Finished in 1.3 seconds (0.5s async, 0.7s sync)
58 tests, 0 failures

Randomized with seed 155869
```

### After

```
$ mix test
warning: Phoenix now requires you to explicitly list which engine to use
for Phoenix JSON encoding. We recommend everyone to upgrade to
Jason by setting in your config/config.exs:

    config :phoenix, :json_library, Jason

And then adding {:jason, "~> 1.0"} as a dependency.

If instead you would rather continue using Poison, then add to
your config/config.exs:

    config :phoenix, :json_library, Poison

  (phoenix 1.5.10) lib/phoenix.ex:38: Phoenix.start/2
  (kernel 8.0.1) application_master.erl:293: :application_master.start_it_old/4

..........................................................

Finished in 1.3 seconds (0.5s async, 0.7s sync)
58 tests, 0 failures

Randomized with seed 980171
```