### PR TITLE
Add json config for phoenix

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,5 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env()}.exs"
+
+config :phoenix, :json_library, Jason


### PR DESCRIPTION
## Before

```
› mix test
warning: Phoenix now requires you to explicitly list which engine to use
for Phoenix JSON encoding. We recommend everyone to upgrade to
Jason by setting in your config/config.exs:

    config :phoenix, :json_library, Jason

And then adding {:jason, "~> 1.0"} as a dependency.

If instead you would rather continue using Poison, then add to
your config/config.exs:

    config :phoenix, :json_library, Poison

  (phoenix 1.5.10) lib/phoenix.ex:38: Phoenix.start/2
  (kernel 8.0.1) application_master.erl:293: :application_master.start_it_old/4

..........................................................

Finished in 1.4 seconds (0.7s async, 0.7s sync)
58 tests, 0 failures

Randomized with seed 297994
```

## After

```
› mix test
..........................................................

Finished in 1.4 seconds (0.7s async, 0.7s sync)
58 tests, 0 failures

Randomized with seed 215301
```

## Notes

I had the doubt if adding some configuration here would affect users using the library, and I find the following paragraph in the [Config](https://hexdocs.pm/elixir/master/Config.html) docs: `Also note that the config/config.exs of a library is not evaluated when the library is used as a dependency, as configuration is always meant to configure the current project.`