### PR TITLE
Refactor error storage data

### DIFF
--- a/lib/boom_notifier.ex
+++ b/lib/boom_notifier.ex
@@ -78,8 +78,7 @@ defmodule BoomNotifier do
 
           # Triggers the notification for each notifier
           walkthrough_notifiers(settings, fn notifier, options ->
-            # TODO remove occurrence list
-            NotifierSenderServer.send(notifier, [occurrence], options)
+            NotifierSenderServer.send(notifier, occurrence, options)
           end)
 
           {notification_trigger, _settings} =

--- a/lib/boom_notifier.ex
+++ b/lib/boom_notifier.ex
@@ -68,8 +68,7 @@ defmodule BoomNotifier do
 
         {custom_data, _settings} = Keyword.pop(settings, :custom_data, :nothing)
 
-        # TODO remove error_kind
-        {_error_kind, error_info} = ErrorInfo.build(error, conn, custom_data)
+        error_info = ErrorInfo.build(error, conn, custom_data)
 
         ErrorStorage.add_error(error_info)
 

--- a/lib/boom_notifier/error_info.ex
+++ b/lib/boom_notifier/error_info.ex
@@ -35,11 +35,11 @@ defmodule ErrorInfo do
           },
           map(),
           custom_data_strategy_type
-        ) :: {atom(), %ErrorInfo{}}
-  def build(%{reason: reason, stack: stack} = error, conn, custom_data_strategy) do
+        ) :: %ErrorInfo{}
+  def build(%{reason: reason, stack: stack}, conn, custom_data_strategy) do
     {error_reason, error_name} = error_reason(reason)
 
-    error_info = %ErrorInfo{
+    %ErrorInfo{
       reason: error_reason,
       stack: stack,
       controller: get_in(conn.private, [:phoenix_controller]),
@@ -48,18 +48,12 @@ defmodule ErrorInfo do
       name: error_name,
       metadata: build_custom_data(conn, custom_data_strategy)
     }
-
-    {error_type(error), error_info}
   end
 
   defp error_reason(%name{message: reason}), do: {reason, name}
   defp error_reason(%{message: reason}), do: {reason, "Error"}
   defp error_reason(reason) when is_binary(reason), do: error_reason(%{message: reason})
   defp error_reason(reason), do: error_reason(%{message: inspect(reason)})
-
-  defp error_type(%{reason: %name{}}), do: name
-  defp error_type(%{error: %{kind: kind}}), do: kind
-  defp error_type(_), do: :error
 
   defp build_request_info(conn) do
     %{

--- a/lib/boom_notifier/error_info.ex
+++ b/lib/boom_notifier/error_info.ex
@@ -6,8 +6,19 @@ defmodule ErrorInfo do
   # (information about the request, the current controller and action,
   # among other things) and custom data depending on the configuration.
 
-  @enforce_keys [:reason, :stack, :timestamp]
-  defstruct [:name, :reason, :stack, :controller, :action, :request, :timestamp, :metadata]
+  @enforce_keys [:reason, :stack]
+  defstruct [
+    :name,
+    :reason,
+    :stack,
+    :controller,
+    :action,
+    :request,
+    :metadata,
+    :accumulated_occurrences,
+    :first_occurrence,
+    :last_occurrence
+  ]
 
   @type option ::
           :logger
@@ -34,7 +45,6 @@ defmodule ErrorInfo do
       controller: get_in(conn.private, [:phoenix_controller]),
       action: get_in(conn.private, [:phoenix_action]),
       request: build_request_info(conn),
-      timestamp: DateTime.utc_now(),
       name: error_name,
       metadata: build_custom_data(conn, custom_data_strategy)
     }

--- a/lib/boom_notifier/error_storage.ex
+++ b/lib/boom_notifier/error_storage.ex
@@ -4,6 +4,8 @@ defmodule BoomNotifier.ErrorStorage do
   # Keeps track of the errors grouped by type and a counter so the notifier
   # knows the next time it should be executed
 
+  defstruct [:accumulated_occurrences, :first_occurrence, :last_occurrence]
+
   use Agent, start: {__MODULE__, :start_link, []}
 
   @spec start_link() :: Agent.on_start()
@@ -11,57 +13,114 @@ defmodule BoomNotifier.ErrorStorage do
     Agent.start_link(fn -> %{} end, name: :boom_notifier)
   end
 
-  @spec add_errors(atom(), %ErrorInfo{}) :: :ok
-  def add_errors(error_kind, error_info) do
+  @spec add_error(%ErrorInfo{}) :: :ok
+  def add_error(error_info) do
+    error_hash_key = generate_error_key(error_info)
+    timestamp = DateTime.utc_now()
+
     Agent.update(
       :boom_notifier,
-      &Map.update(&1, error_kind, {1, [error_info]}, fn {counter, errors} ->
-        {counter, [error_info | errors]}
-      end)
+      &Map.update(
+        &1,
+        error_hash_key,
+        %{
+          accumulated_occurrences: 1,
+          max_storage_capacity: 1,
+          first_occurrence: timestamp,
+          last_occurrence: timestamp
+        },
+        fn error_storage_item ->
+          error_storage_item
+          |> Map.update!(:accumulated_occurrences, fn current -> current + 1 end)
+          |> Map.update!(:first_occurrence, fn first_occurrence ->
+            first_occurrence || timestamp
+          end)
+          |> Map.update!(:last_occurrence, fn _ -> timestamp end)
+        end
+      )
     )
   end
 
-  @spec get_errors(atom()) :: list(%ErrorInfo{})
-  def get_errors(error_kind) do
+  @spec get_error_storage_item(%ErrorInfo{}) :: %__MODULE__{}
+  def get_error_storage_item(error_info) do
+    error_hash_key = generate_error_key(error_info)
+
     Agent.get(:boom_notifier, fn state -> state end)
-    |> Map.get(error_kind)
-    |> case do
-      nil -> nil
-      {_counter, errors} -> errors
-    end
+    |> Map.get(error_hash_key)
   end
 
-  @spec send_notification?(atom()) :: boolean()
-  def send_notification?(error_kind) do
-    Agent.get(:boom_notifier, fn state -> state end)
-    |> Map.get(error_kind)
-    |> case do
-      nil -> false
-      {counter, errors} -> length(errors) >= counter
-    end
+  @spec send_notification?(%ErrorInfo{}) :: boolean()
+  def send_notification?(error_info) do
+    error_hash_key = generate_error_key(error_info)
+
+    error_storage_item =
+      Agent.get(:boom_notifier, fn state -> state end)
+      |> Map.get(error_hash_key)
+
+    accumulated_occurrences = Map.get(error_storage_item, :accumulated_occurrences)
+    max_storage_capacity = Map.get(error_storage_item, :max_storage_capacity)
+
+    if accumulated_occurrences >= max_storage_capacity, do: true, else: false
   end
 
   @type error_strategy :: :always | :exponential | [exponential: [limit: non_neg_integer()]]
 
-  @spec clear_errors(error_strategy, atom()) :: :ok
-  def clear_errors(:exponential, error_kind) do
+  @spec reset_accumulated_errors(error_strategy, %ErrorInfo{}) :: :ok
+  def reset_accumulated_errors(:exponential, error_info) do
+    error_hash_key = generate_error_key(error_info)
+
     Agent.update(
       :boom_notifier,
-      &Map.update!(&1, error_kind, fn {counter, _errors} -> {counter * 2, []} end)
+      &Map.update!(&1, error_hash_key, fn error_storage_item ->
+        clear_values(error_storage_item)
+        |> Map.update!(:max_storage_capacity, fn current -> current * 2 end)
+      end)
     )
   end
 
-  def clear_errors([exponential: [limit: limit]], error_kind) do
+  def reset_accumulated_errors([exponential: [limit: limit]], error_info) do
+    error_hash_key = generate_error_key(error_info)
+
     Agent.update(
       :boom_notifier,
-      &Map.update!(&1, error_kind, fn {counter, _errors} -> {min(counter * 2, limit), []} end)
+      &Map.update!(&1, error_hash_key, fn error_storage_item ->
+        clear_values(error_storage_item)
+        |> Map.update!(:max_storage_capacity, fn current -> min(current * 2, limit) end)
+      end)
     )
   end
 
-  def clear_errors(:always, error_kind) do
+  def reset_accumulated_errors(:always, error_info) do
+    error_hash_key = generate_error_key(error_info)
+
     Agent.update(
       :boom_notifier,
-      &Map.update!(&1, error_kind, fn _value -> {1, []} end)
+      &Map.update!(&1, error_hash_key, fn error_storage_item ->
+        clear_values(error_storage_item)
+        |> Map.replace!(:max_storage_capacity, 1)
+      end)
     )
+  end
+
+  # Generates a unique hash key based on the error info. The timestamp and the
+  # request info is removed so we don't get different keys for the same error.
+  #
+  # The map is converted to a string using `inspect()` so we can hash it using
+  # the crc32 algorithm that was taken from the Exception Notification library
+  # for Rails
+  @spec generate_error_key(%ErrorInfo{}) :: non_neg_integer()
+  defp generate_error_key(error_info) do
+    error_info
+    |> Map.delete(:request)
+    |> Map.delete(:timestamp)
+    |> inspect()
+    |> :erlang.crc32()
+  end
+
+  defp clear_values(error_storage_item) do
+    error_storage_item
+    |> Map.replace!(:accumulated_occurrences, 0)
+    |> Map.replace!(:first_occurrence, nil)
+    |> Map.replace!(:last_occurrence, nil)
   end
 end

--- a/lib/boom_notifier/mail_notifier.ex
+++ b/lib/boom_notifier/mail_notifier.ex
@@ -43,13 +43,13 @@ defmodule BoomNotifier.MailNotifier do
   end
 
   @impl BoomNotifier.Notifier
-  @spec notify(list(%ErrorInfo{}), options) :: no_return()
+  @spec notify(%ErrorInfo{}, options) :: no_return()
   def notify(error_info, options) do
     email =
       new_email()
       |> to(options[:to])
       |> from(options[:from])
-      |> subject("#{options[:subject]}: #{hd(error_info) |> Map.get(:reason)}")
+      |> subject("#{options[:subject]}: #{error_info |> Map.get(:reason)}")
       |> html_body(HTMLContent.build(error_info))
       |> text_body(TextContent.build(error_info))
 

--- a/lib/boom_notifier/mail_notifier/html_content.ex
+++ b/lib/boom_notifier/mail_notifier/html_content.ex
@@ -21,8 +21,10 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
         action: action,
         request: request,
         stack: stack,
-        timestamp: timestamp,
-        metadata: metadata
+        metadata: metadata,
+        first_occurrence: first_occurrence,
+        last_occurrence: last_occurrence,
+        accumulated_occurrences: accumulated_occurrences
       }) do
     exception_summary =
       if controller && action do
@@ -33,8 +35,10 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
       exception_summary: exception_summary,
       request: request,
       exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
-      timestamp: format_timestamp(timestamp),
-      metadata: metadata
+      metadata: metadata,
+      first_occurrence: format_timestamp(first_occurrence),
+      last_occurrence: format_timestamp(last_occurrence),
+      accumulated_occurrences: accumulated_occurrences
     }
   end
 

--- a/lib/boom_notifier/mail_notifier/html_content.ex
+++ b/lib/boom_notifier/mail_notifier/html_content.ex
@@ -8,12 +8,8 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
     :def,
     :email_body,
     Path.join([Path.dirname(__ENV__.file), "templates", "email_body.html.eex"]),
-    [:errors]
+    [:error]
   )
-
-  def build(errors) when is_list(errors) do
-    email_body(Enum.map(errors, &build/1))
-  end
 
   def build(%ErrorInfo{
         name: name,
@@ -40,6 +36,7 @@ defmodule BoomNotifier.MailNotifier.HTMLContent do
       last_occurrence: format_timestamp(last_occurrence),
       accumulated_occurrences: accumulated_occurrences
     }
+    |> email_body()
   end
 
   defp format_timestamp(timestamp) do

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -1,16 +1,19 @@
 <%= for error <- errors do %>
   <p><%= error.exception_summary %></p>
+
   <%= if error.request do %>
-    <ul style="list-style-type: none;">
-      <li>Request Information:</li>
-      <li>URL: <%= error.request.url %></li>
-      <li>Path: <%= error.request.path %></li>
-      <li>Method: <%= error.request.method %></li>
-      <li>Port: <%= error.request.port %></li>
-      <li>Scheme: <%= error.request.scheme %></li>
-      <li>Query String: <%= error.request.query_string %></li>
-      <li>Client IP: <%= error.request.client_ip %></li>
-    </ul>
+    <div>
+      Request Information:
+      <ul style="list-style-type: none;">
+        <li>URL: <%= error.request.url %></li>
+        <li>Path: <%= error.request.path %></li>
+        <li>Method: <%= error.request.method %></li>
+        <li>Port: <%= error.request.port %></li>
+        <li>Scheme: <%= error.request.scheme %></li>
+        <li>Query String: <%= error.request.query_string %></li>
+        <li>Client IP: <%= error.request.client_ip %></li>
+      </ul>
+    </div>
   <% end %>
 
   <div>
@@ -30,26 +33,31 @@
   </div>
 
   <%= if error.metadata do %>
-    <ul style="list-style-type: none;">
-      <li>
-        Metadata:
-        <ul style="list-style-type: none;">
-          <%= for {source, fields} <- error.metadata do %>
-            <%= source %>: 
-              <ul style="list-style-type: none;">
-                <%= for {k, v} <- fields do %>
-                  <li><%= k %>: <%= v %> </li>
-                <% end %>
-              </ul>
-          <% end %>
-        </ul>
-      </li>
-    </ul>
+    <div>
+      Metadata:
+      <ul style="list-style-type: none;">
+        <li>
+          <ul style="list-style-type: none;">
+            <%= for {source, fields} <- error.metadata do %>
+              <%= source %>:
+                <ul style="list-style-type: none;">
+                  <%= for {k, v} <- fields do %>
+                    <li><%= k %>: <%= v %> </li>
+                  <% end %>
+                </ul>
+            <% end %>
+          </ul>
+        </li>
+      </ul>
+    </div>
   <% end %>
-  <ul style="list-style-type: none;">
-    <%= for entry <- error.exception_stack_entries do %>
-      <li><%= entry %></li>
-    <% end %>
-  </ul>
-  <hr>
+
+  <div>
+    Stack entries:
+    <ul style="list-style-type: none;">
+      <%= for entry <- error.exception_stack_entries do %>
+        <li><%= entry %></li>
+      <% end %>
+    </ul>
+  </div>
 <% end %>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -1,63 +1,61 @@
-<%= for error <- errors do %>
-  <p><%= error.exception_summary %></p>
+<p><%= error.exception_summary %></p>
 
-  <%= if error.request do %>
-    <div>
-      Request Information:
-      <ul style="list-style-type: none;">
-        <li>URL: <%= error.request.url %></li>
-        <li>Path: <%= error.request.path %></li>
-        <li>Method: <%= error.request.method %></li>
-        <li>Port: <%= error.request.port %></li>
-        <li>Scheme: <%= error.request.scheme %></li>
-        <li>Query String: <%= error.request.query_string %></li>
-        <li>Client IP: <%= error.request.client_ip %></li>
-      </ul>
-    </div>
-  <% end %>
-
+<%= if error.request do %>
   <div>
-    <%= if error.accumulated_occurrences == 1 do %>
-      Occurred on:
-      <ul style="list-style-type: none;">
-        <li><%= error.first_occurrence %></li>
-      </ul>
-    <% else %>
-      Occurred on:
-      <ul style="list-style-type: none;">
-        <li>First occurrence: <%= error.first_occurrence %></li>
-        <li>Last occurrence: <%= error.last_occurrence %></li>
-        <li>Accumulated occurrences: <%= error.accumulated_occurrences %></li>
-      </ul>
-    <% end %>
-  </div>
-
-  <%= if error.metadata do %>
-    <div>
-      Metadata:
-      <ul style="list-style-type: none;">
-        <li>
-          <ul style="list-style-type: none;">
-            <%= for {source, fields} <- error.metadata do %>
-              <%= source %>:
-                <ul style="list-style-type: none;">
-                  <%= for {k, v} <- fields do %>
-                    <li><%= k %>: <%= v %> </li>
-                  <% end %>
-                </ul>
-            <% end %>
-          </ul>
-        </li>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    Stack entries:
+    Request Information:
     <ul style="list-style-type: none;">
-      <%= for entry <- error.exception_stack_entries do %>
-        <li><%= entry %></li>
-      <% end %>
+      <li>URL: <%= error.request.url %></li>
+      <li>Path: <%= error.request.path %></li>
+      <li>Method: <%= error.request.method %></li>
+      <li>Port: <%= error.request.port %></li>
+      <li>Scheme: <%= error.request.scheme %></li>
+      <li>Query String: <%= error.request.query_string %></li>
+      <li>Client IP: <%= error.request.client_ip %></li>
     </ul>
   </div>
 <% end %>
+
+<div>
+  <%= if error.accumulated_occurrences == 1 do %>
+    Occurred on:
+    <ul style="list-style-type: none;">
+      <li><%= error.first_occurrence %></li>
+    </ul>
+  <% else %>
+    Occurred on:
+    <ul style="list-style-type: none;">
+      <li>First occurrence: <%= error.first_occurrence %></li>
+      <li>Last occurrence: <%= error.last_occurrence %></li>
+      <li>Accumulated occurrences: <%= error.accumulated_occurrences %></li>
+    </ul>
+  <% end %>
+</div>
+
+<%= if error.metadata do %>
+  <div>
+    Metadata:
+    <ul style="list-style-type: none;">
+      <li>
+        <ul style="list-style-type: none;">
+          <%= for {source, fields} <- error.metadata do %>
+            <%= source %>:
+              <ul style="list-style-type: none;">
+                <%= for {k, v} <- fields do %>
+                  <li><%= k %>: <%= v %> </li>
+                <% end %>
+              </ul>
+          <% end %>
+        </ul>
+      </li>
+    </ul>
+  </div>
+<% end %>
+
+<div>
+  Stack entries:
+  <ul style="list-style-type: none;">
+    <%= for entry <- error.exception_stack_entries do %>
+      <li><%= entry %></li>
+    <% end %>
+  </ul>
+</div>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -12,9 +12,23 @@
       <li>Client IP: <%= error.request.client_ip %></li>
     </ul>
   <% end %>
-  <ul style="list-style-type: none;">
-    <li>Occurred on: <%= error.timestamp %></li>
-  </ul>
+
+  <div>
+    <%= if error.accumulated_occurrences == 1 do %>
+      Occurred on:
+      <ul style="list-style-type: none;">
+        <li><%= error.first_occurrence %></li>
+      </ul>
+    <% else %>
+      Occurred on:
+      <ul style="list-style-type: none;">
+        <li>First occurrence: <%= error.first_occurrence %></li>
+        <li>Last occurrence: <%= error.last_occurrence %></li>
+        <li>Accumulated occurrences: <%= error.accumulated_occurrences %></li>
+      </ul>
+    <% end %>
+  </div>
+
   <%= if error.metadata do %>
     <ul style="list-style-type: none;">
       <li>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
@@ -1,41 +1,37 @@
-<%= for error <- errors do %>
-  <%= if error.exception_summary do %>
-    <%= error.exception_summary %>
-  <% end %>
-  <%= if error.request do %>
-    Request Information:
-      URL: <%= error.request.url %>
-      Path: <%= error.request.path %>
-      Method: <%= error.request.method %>
-      Port: <%= error.request.port %>
-      Scheme: <%= error.request.scheme %>
-      Query String: <%= error.request.query_string %>
-      Client IP: <%= error.request.client_ip %>
-  <% end %>
+<%= if error.exception_summary do %>
+  <%= error.exception_summary %>
+<% end %>
+<%= if error.request do %>
+  Request Information:
+    URL: <%= error.request.url %>
+    Path: <%= error.request.path %>
+    Method: <%= error.request.method %>
+    Port: <%= error.request.port %>
+    Scheme: <%= error.request.scheme %>
+    Query String: <%= error.request.query_string %>
+    Client IP: <%= error.request.client_ip %>
+<% end %>
 
-  <%= if error.accumulated_occurrences == 1 do %>
-    Occurred on: <%= error.first_occurrence %>
-  <% else %>
-    Occurred on:
-      First occurrence: <%= error.first_occurrence %>
-      Last occurrence: <%= error.last_occurrence %>
-      Accumulated occurrences: <%= error.accumulated_occurrences %>
-  <% end %>
+<%= if error.accumulated_occurrences == 1 do %>
+  Occurred on: <%= error.first_occurrence %>
+<% else %>
+  Occurred on:
+    First occurrence: <%= error.first_occurrence %>
+    Last occurrence: <%= error.last_occurrence %>
+    Accumulated occurrences: <%= error.accumulated_occurrences %>
+<% end %>
 
-  <%= if error.metadata do %>
-    Metadata:
-    <%= for {source, fields} <- error.metadata do %>
-      <%= source %>:
-        <%= for {k, v} <- fields do %>
-          <%= k %>: <%= v %>
-        <% end %>
-    <% end %>
+<%= if error.metadata do %>
+  Metadata:
+  <%= for {source, fields} <- error.metadata do %>
+    <%= source %>:
+      <%= for {k, v} <- fields do %>
+        <%= k %>: <%= v %>
+      <% end %>
   <% end %>
+<% end %>
 
-  Stack entries:
-  <%= for entry <- error.exception_stack_entries do %>
-    <%= entry %>
-  <% end %>
-
-  ----------------------------------------
+Stack entries:
+<%= for entry <- error.exception_stack_entries do %>
+  <%= entry %>
 <% end %>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
@@ -25,12 +25,14 @@
   <%= if error.metadata do %>
     Metadata:
     <%= for {source, fields} <- error.metadata do %>
-      <%= source %>: 
+      <%= source %>:
         <%= for {k, v} <- fields do %>
-          <%= k %>: <%= v %> 
+          <%= k %>: <%= v %>
         <% end %>
     <% end %>
   <% end %>
+
+  Stack entries:
   <%= for entry <- error.exception_stack_entries do %>
     <%= entry %>
   <% end %>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
@@ -12,7 +12,16 @@
       Query String: <%= error.request.query_string %>
       Client IP: <%= error.request.client_ip %>
   <% end %>
-  Occurred on: <%= error.timestamp %>
+
+  <%= if error.accumulated_occurrences == 1 do %>
+    Occurred on: <%= error.first_occurrence %>
+  <% else %>
+    Occurred on:
+      First occurrence: <%= error.first_occurrence %>
+      Last occurrence: <%= error.last_occurrence %>
+      Accumulated occurrences: <%= error.accumulated_occurrences %>
+  <% end %>
+
   <%= if error.metadata do %>
     Metadata:
     <%= for {source, fields} <- error.metadata do %>

--- a/lib/boom_notifier/mail_notifier/text_content.ex
+++ b/lib/boom_notifier/mail_notifier/text_content.ex
@@ -8,12 +8,8 @@ defmodule BoomNotifier.MailNotifier.TextContent do
     :def,
     :email_body,
     Path.join([Path.dirname(__ENV__.file), "templates", "email_body.text.eex"]),
-    [:errors]
+    [:error]
   )
-
-  def build(errors) when is_list(errors) do
-    email_body(Enum.map(errors, &build/1))
-  end
 
   def build(%ErrorInfo{
         name: name,
@@ -40,6 +36,7 @@ defmodule BoomNotifier.MailNotifier.TextContent do
       accumulated_occurrences: accumulated_occurrences,
       metadata: metadata
     }
+    |> email_body()
   end
 
   defp format_timestamp(timestamp) do

--- a/lib/boom_notifier/mail_notifier/text_content.ex
+++ b/lib/boom_notifier/mail_notifier/text_content.ex
@@ -21,8 +21,10 @@ defmodule BoomNotifier.MailNotifier.TextContent do
         action: action,
         request: request,
         stack: stack,
-        timestamp: timestamp,
-        metadata: metadata
+        metadata: metadata,
+        first_occurrence: first_occurrence,
+        last_occurrence: last_occurrence,
+        accumulated_occurrences: accumulated_occurrences
       }) do
     exception_summary =
       if controller && action do
@@ -33,7 +35,9 @@ defmodule BoomNotifier.MailNotifier.TextContent do
       exception_summary: exception_summary,
       request: request,
       exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
-      timestamp: format_timestamp(timestamp),
+      first_occurrence: format_timestamp(first_occurrence),
+      last_occurrence: format_timestamp(last_occurrence),
+      accumulated_occurrences: accumulated_occurrences,
       metadata: metadata
     }
   end

--- a/lib/boom_notifier/notifier.ex
+++ b/lib/boom_notifier/notifier.ex
@@ -3,7 +3,7 @@ defmodule BoomNotifier.Notifier do
   Defines a callback to be used by custom notifiers
   """
 
-  @callback notify(list(%ErrorInfo{}), keyword(String.t())) :: no_return()
+  @callback notify(%ErrorInfo{}, keyword(String.t())) :: no_return()
   @callback validate_config(keyword(String.t())) :: :ok | {:error, String.t()}
   @optional_callbacks validate_config: 1
 end

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -53,8 +53,10 @@ defmodule BoomNotifier.WebhookNotifier do
          action: action,
          request: request,
          stack: stack,
-         timestamp: timestamp,
-         metadata: metadata
+         metadata: metadata,
+         first_occurrence: first_occurrence,
+         last_occurrence: last_occurrence,
+         accumulated_occurrences: accumulated_occurrences
        }) do
     exception_summary =
       if controller && action do
@@ -65,8 +67,10 @@ defmodule BoomNotifier.WebhookNotifier do
       exception_summary: exception_summary,
       request: request,
       exception_stack_entries: Enum.map(stack, &Exception.format_stacktrace_entry/1),
-      timestamp: DateTime.to_iso8601(timestamp),
-      metadata: metadata
+      metadata: metadata,
+      first_occurrence: DateTime.to_iso8601(first_occurrence),
+      last_occurrence: DateTime.to_iso8601(last_occurrence),
+      accumulated_occurrences: accumulated_occurrences
     }
   end
 end

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -33,18 +33,14 @@ defmodule BoomNotifier.WebhookNotifier do
   end
 
   @impl BoomNotifier.Notifier
-  @spec notify(list(%ErrorInfo{}), options) :: no_return()
-  def notify(errors_info, url: url) do
+  @spec notify(%ErrorInfo{}, options) :: no_return()
+  def notify(error_info, url: url) do
     payload =
-      errors_info
-      |> format_errors()
+      error_info
+      |> format_error()
       |> Jason.encode!()
 
     HTTPoison.post!(url, payload, [{"Content-Type", "application/json"}])
-  end
-
-  defp format_errors(errors) when is_list(errors) do
-    Enum.map(errors, &format_error/1)
   end
 
   defp format_error(%ErrorInfo{

--- a/test/error_info_test.exs
+++ b/test/error_info_test.exs
@@ -76,21 +76,19 @@ defmodule ErrorInfoTest do
   test "Generic error without exception name" do
     %Plug.Conn.WrapperError{conn: conn} = catch_error(get(build_conn(), :index))
     error = %{reason: "Boom", stack: []}
-    {error_kind, %ErrorInfo{name: name, reason: reason}} = ErrorInfo.build(error, conn, :nothing)
+    %ErrorInfo{name: name, reason: reason} = ErrorInfo.build(error, conn, :nothing)
 
     assert "Error" = name
     assert "Boom" = reason
-    assert :error = error_kind
   end
 
   test "Error without exception name but message" do
     %Plug.Conn.WrapperError{conn: conn} = catch_error(get(build_conn(), :index))
     error = %{reason: %{message: "Boom"}, stack: []}
-    {error_kind, %ErrorInfo{name: name, reason: reason}} = ErrorInfo.build(error, conn, :nothing)
+    %ErrorInfo{name: name, reason: reason} = ErrorInfo.build(error, conn, :nothing)
 
     assert "Error" = name
     assert "Boom" = reason
-    assert :error = error_kind
   end
 
   test "Error with exception name" do
@@ -98,27 +96,25 @@ defmodule ErrorInfoTest do
 
     error = %{reason: %TestException{message: "Boom"}, stack: []}
 
-    {error_kind, %ErrorInfo{name: name, reason: reason}} = ErrorInfo.build(error, conn, :nothing)
+    %ErrorInfo{name: name, reason: reason} = ErrorInfo.build(error, conn, :nothing)
 
     assert ErrorInfoTest.TestException = name
     assert "Boom" = reason
-    assert ErrorInfoTest.TestException = error_kind
   end
 
-  test "Error without exception reason but error and kind" do
+  test "Error without exception reason" do
     %Plug.Conn.WrapperError{conn: conn} = catch_error(get(build_conn(), :index))
     error = %{error: %{kind: :error_kind}, reason: %{message: "Boom"}, stack: []}
-    {error_kind, %ErrorInfo{name: name, reason: reason}} = ErrorInfo.build(error, conn, :nothing)
+    %ErrorInfo{name: name, reason: reason} = ErrorInfo.build(error, conn, :nothing)
 
     assert "Error" = name
     assert "Boom" = reason
-    assert :error_kind = error_kind
   end
 
   test "Error info includes action" do
     %Plug.Conn.WrapperError{conn: conn} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{action: action}} =
+    %ErrorInfo{action: action} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: []}, conn, :nothing)
 
     assert :index = action
@@ -127,7 +123,7 @@ defmodule ErrorInfoTest do
   test "Error info includes controller" do
     %Plug.Conn.WrapperError{conn: conn} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{controller: controller}} =
+    %ErrorInfo{controller: controller} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: []}, conn, :nothing)
 
     assert TestController = controller
@@ -136,7 +132,7 @@ defmodule ErrorInfoTest do
   test "Error info includes request info" do
     %Plug.Conn.WrapperError{conn: conn} = catch_error(post(build_conn(), "/create?foo=bar"))
 
-    {_error_kind, %ErrorInfo{request: request}} =
+    %ErrorInfo{request: request} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: []}, conn, :nothing)
 
     assert %{
@@ -153,7 +149,7 @@ defmodule ErrorInfoTest do
   test "Error info includes stacktrace" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{stack: error_info_stack}} =
+    %ErrorInfo{stack: error_info_stack} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :nothing)
 
     assert {
@@ -177,7 +173,7 @@ defmodule ErrorInfoTest do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} =
       catch_error(get(build_conn(), "nil_access"))
 
-    {_error_kind, %ErrorInfo{stack: error_info_stack}} =
+    %ErrorInfo{stack: error_info_stack} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :nothing)
 
     assert {nil, :name, [], []} = hd(error_info_stack)
@@ -195,7 +191,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata is nil when strategy is :nothing" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :nothing)
 
     assert nil == metadata
@@ -204,7 +200,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata includes assigns" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :assigns)
 
     assert %{assigns: %{age: 32, name: "Davis"}} = metadata
@@ -213,7 +209,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata includes filtered fields for assigns" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn,
         assigns: [fields: [:name]]
       )
@@ -224,7 +220,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata includes logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :logger)
 
     assert %{logger: %{age: 17, name: "Dennis"}} = metadata
@@ -233,7 +229,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata includes filtered fields for logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn,
         logger: [fields: [:name]]
       )
@@ -244,7 +240,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata includes assigns and logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, [
         :assigns,
         :logger
@@ -259,7 +255,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata includes filtered fields for assigns and logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, [
         [assigns: [fields: [:name]]],
         [logger: [fields: [:age]]]
@@ -271,7 +267,7 @@ defmodule ErrorInfoTest do
   test "Error info metadata includes filtered equal fields for assigns and logger" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 
-    {_error_kind, %ErrorInfo{metadata: metadata}} =
+    %ErrorInfo{metadata: metadata} =
       ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, [
         [assigns: [fields: [:name]]],
         [logger: [fields: [:name]]]

--- a/test/error_info_test.exs
+++ b/test/error_info_test.exs
@@ -192,15 +192,6 @@ defmodule ErrorInfoTest do
     assert 10 = Enum.count(error_info_stack)
   end
 
-  test "Error info includes timestamp" do
-    %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
-
-    {_error_kind, %ErrorInfo{timestamp: timestamp}} =
-      ErrorInfo.build(%{reason: %TestException{message: "Boom"}, stack: stack}, conn, :nothing)
-
-    assert DateTime.diff(DateTime.utc_now(), timestamp, :second) <= 1
-  end
-
   test "Error info metadata is nil when strategy is :nothing" do
     %Plug.Conn.WrapperError{conn: conn, stack: stack} = catch_error(get(build_conn(), :index))
 


### PR DESCRIPTION
#### 🚨🚨🚨 **This is a breaking change and it might affect custom notifiers**

Currently, we are grouping every error information in several lists
according to its error type. Eventually, this could consume a lot of
memory without providing any important benefit (the only piece of
information that changes is the timestamp and the request data).

This commit replaces that with a map structure where its key is the
hashed error info and its value is the actual error info plus:
  * the number of times this error occurred,
  * the first and the list time it happened.
  