### PR TITLE
Add optional header parameter in webhook notifier

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -79,7 +79,7 @@ jobs:
       id: plt-cache
       with:
         path: priv/plts
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles('mix.lock') }}
+        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-v2-${{ hashFiles('mix.lock') }}
       if: ${{ matrix.lint }}
 
     - name: Create PLTs
@@ -92,7 +92,7 @@ jobs:
       run: |
         mix format --check-formatted
         mix credo --strict
-        mix dialyzer --no-check --halt-exit-status
+        mix dialyzer --no-check
       if: ${{ matrix.lint }}
 
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -38,13 +38,15 @@ defmodule YourApp.Router do
   use BoomNotifier,
     notifier: BoomNotifier.WebhookNotifier,
     options: [
-      url: "http://example.com"
+      url: "http://example.com",
+      headers: [Authorization: "Bearer token"]
     ]
 
   # ...
 ```
 
 To configure it, you need to set the `url` in the `options` keyword list. A `POST` request with a `json` will be made to that webhook when an error ocurrs with the relevant information.
+Optionally, you could also add `headers` to the request as another keyword list.
 
 ### Email notifier
 

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -22,7 +22,8 @@ defmodule BoomNotifier.WebhookNotifier do
 
   import BoomNotifier.Helpers
 
-  @type options :: [{:url, String.t()}, {:headers, Keyword.t()}]
+  @type options ::
+          [{:url, String.t()}] | [{:url, String.t()}, {:headers, HTTPoison.Request.headers()}]
 
   @impl BoomNotifier.Notifier
   def validate_config(options) do

--- a/lib/boom_notifier/webhook_notifier.ex
+++ b/lib/boom_notifier/webhook_notifier.ex
@@ -10,7 +10,8 @@ defmodule BoomNotifier.WebhookNotifier do
   use BoomNotifier,
     notifier: BoomNotifier.WebhookNotifier,
     options: [
-      url: "http://example.com"
+      url: "http://example.com",
+      headers: [Authorization: "Bearer token"]
     ]
 
   # ...
@@ -21,7 +22,7 @@ defmodule BoomNotifier.WebhookNotifier do
 
   import BoomNotifier.Helpers
 
-  @type options :: [{:url, String.t()}]
+  @type options :: [{:url, String.t()}, {:headers, Keyword.t()}]
 
   @impl BoomNotifier.Notifier
   def validate_config(options) do
@@ -34,13 +35,18 @@ defmodule BoomNotifier.WebhookNotifier do
 
   @impl BoomNotifier.Notifier
   @spec notify(list(%ErrorInfo{}), options) :: no_return()
-  def notify(errors_info, url: url) do
+  def notify(errors_info, options) do
     payload =
       errors_info
       |> format_errors()
       |> Jason.encode!()
 
-    HTTPoison.post!(url, payload, [{"Content-Type", "application/json"}])
+    headers =
+      options
+      |> Keyword.get(:headers, [])
+      |> Keyword.merge("Content-Type": "application/json")
+
+    HTTPoison.post!(options[:url], payload, headers)
   end
 
   defp format_errors(errors) when is_list(errors) do

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -73,6 +73,11 @@ defmodule WebhookNotifierTest do
     end
   end
 
+  def header_value(headers, header_name) do
+    Enum.find(headers, fn {header, _value} -> header == header_name end)
+    |> elem(1)
+  end
+
   setup do
     Logger.metadata(name: "Dennis", age: 17)
     bypass = Bypass.open(port: 1234)
@@ -88,9 +93,8 @@ defmodule WebhookNotifierTest do
     Bypass.expect(bypass, fn conn ->
       assert "POST" == conn.method
 
-      [{header_name, header_value} | _] = conn.req_headers
-      assert header_name == "authorization"
-      assert header_value == "Bearer token123"
+      assert header_value(conn.req_headers, "authorization") == "Bearer token123"
+      assert header_value(conn.req_headers, "content-type") == "application/json"
 
       {:ok, body, _conn} = Plug.Conn.read_body(conn)
 

--- a/test/webhook_notifier_test.exs
+++ b/test/webhook_notifier_test.exs
@@ -50,7 +50,10 @@ defmodule WebhookNotifierTest do
 
     use BoomNotifier,
       notifier: BoomNotifier.WebhookNotifier,
-      options: [url: "http://localhost:1234"],
+      options: [
+        url: "http://localhost:1234",
+        headers: [Authorization: "Bearer token123"]
+      ],
       custom_data: [:assigns, :logger]
 
     pipeline :browser do
@@ -84,6 +87,11 @@ defmodule WebhookNotifierTest do
   test "request is sent to webhook", %{bypass: bypass} do
     Bypass.expect(bypass, fn conn ->
       assert "POST" == conn.method
+
+      [{header_name, header_value} | _] = conn.req_headers
+      assert header_name == "authorization"
+      assert header_value == "Bearer token123"
+
       {:ok, body, _conn} = Plug.Conn.read_body(conn)
 
       [


### PR DESCRIPTION
Closes #36.

### Description

These changes add the ability to include an optional `headers` parameter to the Webhook notifier options when configuring the library.

### Example

```elixir
defmodule YourApp.Router do
  use Phoenix.Router

  use BoomNotifier,
    notifier: BoomNotifier.WebhookNotifier,
    options: [
      url: "http://example.com",
      headers: [Authorization: "Bearer token123"]
    ]

  # ...
```

### Screenshot
<img width="1588" alt="Screen Shot 2021-09-20 at 12 58 00 PM" src="https://user-images.githubusercontent.com/26532202/134034335-7f7f49c4-59a7-48cc-9a31-064e4eae39f6.png">

