### PR TITLE
Fix Webhook typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ end
 
 ## How to use it
 
-### Webkook notifier
+### Webhook notifier
 
 ```elixir
 defmodule YourApp.Router do


### PR DESCRIPTION
Changed from `Webkook` to `Webhook`