### PR TITLE
Replace handle_errors with Phoenix.Endpoint overridable call

### DIFF
--- a/lib/boom_notifier/config.ex
+++ b/lib/boom_notifier/config.ex
@@ -7,6 +7,8 @@ defmodule BoomNotifier.Config do
   @ignore_exceptions_default []
   @notifiers_default []
   @notification_trigger_default :always
+  @notifier_default nil
+  @options_default []
 
   def custom_data do
     get_config(:custom_data, @custom_data_default)
@@ -22,6 +24,13 @@ defmodule BoomNotifier.Config do
 
   def notification_trigger do
     get_config(:notification_trigger, @notification_trigger_default)
+  end
+
+  def single_notifier_config do
+    [
+      notifier: get_config(:notifier, @notifier_default),
+      options: get_config(:options, @options_default)
+    ]
   end
 
   defp get_config(key, default) do

--- a/lib/boom_notifier/config.ex
+++ b/lib/boom_notifier/config.ex
@@ -1,0 +1,33 @@
+defmodule BoomNotifier.Config do
+  @moduledoc """
+  This module provides the functionality for fetching configuration settings and their defaults.
+  """
+
+  @custom_data_default :nothing
+  @ignore_exceptions_default []
+  @notifiers_default []
+  @notification_trigger_default :always
+
+  def custom_data do
+    get_config(:custom_data, @custom_data_default)
+  end
+
+  def ignore_exceptions do
+    get_config(:ignore_exceptions, @ignore_exceptions_default)
+  end
+
+  def notifiers do
+    get_config(:notifiers, @notifiers_default)
+  end
+
+  def notification_trigger do
+    get_config(:notification_trigger, @notification_trigger_default)
+  end
+
+  defp get_config(key, default) do
+    case Application.fetch_env(:boom_notifier, key) do
+      {:ok, value} -> value
+      _ -> default
+    end
+  end
+end

--- a/test/support/test_environment_helper.ex
+++ b/test/support/test_environment_helper.ex
@@ -1,0 +1,16 @@
+defmodule Support.TestEnvironmentHelper do
+  def modify_env(app, overrides) do
+    original_env = Application.get_all_env(app)
+    Enum.each(overrides, fn {key, value} -> Application.put_env(app, key, value) end)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      Enum.each(overrides, fn {key, _} ->
+        if Keyword.has_key?(original_env, key) do
+          Application.put_env(app, key, Keyword.fetch!(original_env, key))
+        else
+          Application.delete_env(app, key)
+        end
+      end)
+    end)
+  end
+end


### PR DESCRIPTION
The goal of this change is to move from using the `handle_errors` of `Plug.ErrorHandler` and use the overridable call of `Phoenix.Endpoint`. 

The main advantage of this change is that it is more flexible with the user using the library as currently you can't redefine the `handle_errors` from your app if using boom.

Apart from allowing that, it also works if the user decides to use the overridable call from his application as well. We are overriding it from a `__before_compile__`, and these overrides are kind of "chained" and called one after the other, so the boom code will always be executed at the very beginning.

To achieve this change it was required to change the way of configuring the library, since I have not found a way (and I think it's not possible) to use the config from the `__using__` in the `__before_compile__`.

There are things to improve in what I did, I just made some quick decisions to be able to move forward and be able to open the PR to start discussing things, and follow it together.

### To Do:
- [x] Normalize errors with Exception -> @mcass19 
- [x] Continue supporting only one notifier -> @mcass19 
- [ ] Update readme -> @iaguirre88 
- [ ] Update notifier test -> @iaguirre88 
- [ ] Update remaining tests -> @mcass19 