### PR TITLE
Facelift html emails

### DIFF
--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -1,53 +1,66 @@
 <style>
-.bold {
-  font-weight: bold;
-}
-.font {
-  font-family: ui-sans-serif, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-}
-.margin-b-slim {
-  margin-bottom: 0.5rem;
-}
-.margin-l {
-  margin-left: 1rem;
-}
-.padded {
-  padding: 1rem;
-}
-.padded-slim {
-  padding: 0.5rem;
-}
-.info-list {
-  list-style-type: none;
-  background-color: #f1f5f9;
-}
-.info-sublist {
-  list-style-type: none;
-  background-color: #e2e8f0;
-}
-.mono {
-  font-family: monospace;
-}
-.spaced > * + * {
-  margin-top: 0.25rem;
-}
-.separator {
-  margin-top: 0.25rem;
-}
-.slate-bg {
-  background-color: #f8fafc;
-}
-.table {
-  border-width: 2px;
-  border-color: #f3f4f6;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 1rem;
-  background-color: white;
-}
-.underline {
-  text-decoration: underline;
-}
+  .bold {
+    font-weight: bold;
+  }
+
+  .font {
+    font-family: ui-sans-serif, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  }
+
+  .margin-b-slim {
+    margin-bottom: 0.5rem;
+  }
+
+  .margin-l {
+    margin-left: 1rem;
+  }
+
+  .padded {
+    padding: 1rem;
+  }
+
+  .padded-slim {
+    padding: 0.5rem;
+  }
+
+  .info-list {
+    list-style-type: none;
+    background-color: #f1f5f9;
+  }
+
+  .info-sublist {
+    list-style-type: none;
+    background-color: #e2e8f0;
+  }
+
+  .mono {
+    font-family: monospace;
+  }
+
+  .spaced > * + * {
+    margin-top: 0.25rem;
+  }
+
+  .separator {
+    margin-top: 0.25rem;
+  }
+
+  .slate-bg {
+    background-color: #f8fafc;
+  }
+
+  .table {
+    border-width: 2px;
+    border-color: #f3f4f6;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 1rem;
+    background-color: white;
+  }
+
+  .underline {
+    text-decoration: underline;
+  }
 </style>
 
 <div class="slate-bg font padded">

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -136,7 +136,9 @@
           </td>
         </tr>
       <% end %>
-      <hr />
+      <tr class="padded">
+        <td><hr class="separator" /></td>
+      </tr>
     <% end %>
   </table>
 </div>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.html.eex
@@ -1,47 +1,129 @@
-<%= for error <- errors do %>
-  <p><%= error.exception_summary %></p>
-  <%= if error.request do %>
-    <ul style="list-style-type: none;">
-      <li>Request Information:</li>
-      <li>URL: <%= error.request.url %></li>
-      <li>Path: <%= error.request.path %></li>
-      <li>Method: <%= error.request.method %></li>
-      <li>Port: <%= error.request.port %></li>
-      <li>Scheme: <%= error.request.scheme %></li>
-      <li>Query String: <%= error.request.query_string %></li>
-      <li>Client IP: <%= error.request.client_ip %></li>
-    </ul>
-  <% end %>
-  <ul style="list-style-type: none;">
-    <li>Occurred on: <%= error.timestamp %></li>
-  </ul>
-  <%= if error.metadata do %>
-    <ul style="list-style-type: none;">
-      <li>
-        Metadata:
-        <ul style="list-style-type: none;">
-          <%= for {source, fields} <- error.metadata do %>
-            <%= source %>:
-              <ul style="list-style-type: none;">
-                <%= for {k, v} <- fields do %>
-                  <li><%= k %>: <%= v %> </li>
-                <% end %>
-              </ul>
+<style>
+.bold {
+  font-weight: bold;
+}
+.font {
+  font-family: ui-sans-serif, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+}
+.margin-b-slim {
+  margin-bottom: 0.5rem;
+}
+.margin-l {
+  margin-left: 1rem;
+}
+.padded {
+  padding: 1rem;
+}
+.padded-slim {
+  padding: 0.5rem;
+}
+.info-list {
+  list-style-type: none;
+  background-color: #f1f5f9;
+}
+.info-sublist {
+  list-style-type: none;
+  background-color: #e2e8f0;
+}
+.mono {
+  font-family: monospace;
+}
+.spaced > * + * {
+  margin-top: 0.25rem;
+}
+.separator {
+  margin-top: 0.25rem;
+}
+.slate-bg {
+  background-color: #f8fafc;
+}
+.table {
+  border-width: 2px;
+  border-color: #f3f4f6;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 1rem;
+  background-color: white;
+}
+.underline {
+  text-decoration: underline;
+}
+</style>
+
+<div class="slate-bg font padded">
+  <table class="table padded-slim">
+    <tr>
+      <td class="padded">
+        <h1>Boom! 💣</h1>
+        <hr class="separator" />
+      </td>
+    </tr>
+    <%= for error <- errors do %>
+      <tr>
+        <td class="padded">
+          <h2 class="bold margin-b-slim">Message:</h2>
+          <p class="margin-l">
+            <%= error.exception_summary %>
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td class="padded">
+          <h2 class="bold margin-b-slim">
+            Request Information:
+          </h2>
+          <%= if error.request do %>
+            <ul class="info-list padded spaced">
+              <li><span class="underline">URL:</span> <%= error.request.url %></li>
+              <li><span class="underline">Path:</span> <%= error.request.path %></li>
+              <li><span class="underline">Method:</span> <%= error.request.method %></li>
+              <li><span class="underline">Port:</span> <%= error.request.port %></li>
+              <li><span class="underline">Scheme:</span> <%= error.request.scheme %></li>
+              <li><span class="underline">Query String:</span> <%= error.request.query_string %></li>
+              <li><span class="underline">Client IP:</span> <%= error.request.client_ip %></li>
+              <li><span class="underline">Occurred on:</span> <%= error.timestamp %></li>
+            </ul>
           <% end %>
-        </ul>
-      </li>
-    </ul>
-  <% end %>
-  <ul style="list-style-type: none; font-family: mono;">
-    <%= for entry <- error.exception_stack_entries do %>
-      <li><%= entry %></li>
+        </td>
+      </tr>
+      <%= if error.metadata do %>
+        <tr>
+          <td class="padded">
+            <h2 class="bold margin-b-slim">
+              Metadata:
+            </h2>
+            <ul class="info-list padded spaced">
+              <%= for {source, fields} <- error.metadata do %>
+                <%= source %>:
+                <ul class="info-sublist">
+                  <%= for {k, v} <- fields do %>
+                    <li><%= k %>: <%= v %> </li>
+                  <% end %>
+                </ul>
+              <% end %>
+            </ul>
+          </td>
+        </tr>
+      <% end %>
+      <tr>
+        <td class="padded">
+          <h2 class="bold margin-b-slim">Stacktrace:</h2>
+          <ul class="info-sublist mono padded-slim spaced">
+            <%= for entry <- error.exception_stack_entries do %>
+              <li><%= entry %></li>
+            <% end %>
+          </ul>
+        </td>
+      </tr>
+      <%= if error.reason do %>
+        <tr>
+          <td class="padded">
+            <h2>Reason: </h2>
+            <p><%=  error.reason %></p>
+          </td>
+        </tr>
+      <% end %>
+      <hr />
     <% end %>
-  </ul>
-  <%= if error.reason do %>
-    <p>
-      Reason: <br />
-      <%= error.reason %>
-    </p>
-  <% end %>
-  <hr>
-<% end %>
+  </table>
+</div>

--- a/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
+++ b/lib/boom_notifier/mail_notifier/templates/email_body.text.eex
@@ -11,14 +11,14 @@
       Scheme: <%= error.request.scheme %>
       Query String: <%= error.request.query_string %>
       Client IP: <%= error.request.client_ip %>
+      Occurred on: <%= error.timestamp %>
   <% end %>
-  Occurred on: <%= error.timestamp %>
   <%= if error.metadata do %>
     Metadata:
     <%= for {source, fields} <- error.metadata do %>
-      <%= source %>: 
+      <%= source %>:
         <%= for {k, v} <- fields do %>
-          <%= k %>: <%= v %> 
+          <%= k %>: <%= v %>
         <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Closes: #73 

## Context

Implements new styling for html emails, I ended up inlining css in the template as that seems to be the most email client compatible method.

Regarding css I went with a sort-of utility class approach. But I'm open to modifying it if another style is preferred. Also as you'll probably be able to tell I'm not very knowledgeable on semantic HTML

## Screenshots

**Before**
![image](https://user-images.githubusercontent.com/19378450/148279553-adf3b6fe-b910-46df-a6f5-2c39da9d21f4.png)

**After**
![image](https://user-images.githubusercontent.com/19378450/148278563-e254ac9d-e37a-4da0-9064-146f1859fda6.png)
