### PR TITLE
Manual notify exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ defmodule YourApp.Router do
     ...
 ```
 
+## Manually notify of exception
+
+If your controller action manually handles an error, the notifier will never be run.
+
+To manually notify of an error you can use `BoomNotifier` in your controller and call the `manual_notify_error/2` callback:
+
+```elixir
+defmodule MyController do
+  use BoomNotifier
+
+  def some_action(conn, _params) do
+    try do
+      # ...
+    rescue
+      error ->
+        # ...
+        manual_notify_error(conn, error)
+        # ...
+    end
+  end
+
+  ,
+    ...
+```
+
 ## Custom notifiers
 
 To create a custom notifier, you need to implement the `BoomNotifier.Notifier` behaviour:

--- a/lib/boom_notifier/config.ex
+++ b/lib/boom_notifier/config.ex
@@ -1,0 +1,42 @@
+defmodule BoomNotifier.Config do
+  @moduledoc """
+  This module provides the functionality for fetching configuration settings and their defaults.
+  """
+
+  @custom_data_default :nothing
+  @ignore_exceptions_default []
+  @notifiers_default []
+  @notification_trigger_default :always
+  @notifier_default nil
+  @options_default []
+
+  def custom_data do
+    get_config(:custom_data, @custom_data_default)
+  end
+
+  def ignore_exceptions do
+    get_config(:ignore_exceptions, @ignore_exceptions_default)
+  end
+
+  def notifiers do
+    get_config(:notifiers, @notifiers_default)
+  end
+
+  def notification_trigger do
+    get_config(:notification_trigger, @notification_trigger_default)
+  end
+
+  def single_notifier_config do
+    [
+      notifier: get_config(:notifier, @notifier_default),
+      options: get_config(:options, @options_default)
+    ]
+  end
+
+  defp get_config(key, default) do
+    case Application.fetch_env(:boom_notifier, key) do
+      {:ok, value} -> value
+      _ -> default
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to implement the ability to manually send an exception. It's a first try so feel free to discuss / suggest whatever you want. Actually, there are a few things to discuss and set a direction to go.

## To do / discuss
- I added an extra check to see if we are on the router when defining `handle_errors`. I don't like it too much but I think it covers most of the cases (it doesn't cover if the user defines a module ending in `.Router`)
- I changed the configuration so that it is read from the application environment, since now we can do `use BoomNotifier` anywhere and with the current implementation it would be necessary to always write it
  - But maybe the user wants different settings in different places or am I crazy?
  - Update tests if we keep this change
  - Update readme if we keep this change
- Do we want to always send the `conn` object or do we want to be more open to any elixir code and just send the exception without much more information?
- I defined a new `manual_notify_error` callback, but maybe it is better to have only one `notify_error` that handles all cases?