### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: nanasess/setup-chromedriver@v1.0.7
+    - uses: nanasess/setup-chromedriver@v2
 
     - name: Set up Elixir
       uses: erlef/setup-beam@v1

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Update chromedriver
- Update ubuntu version because latest is not compatible with the current Erlang/OTP versions. See: https://github.com/marketplace/actions/setup-erlang-otp-with-optional-elixir-and-mix-and-or-rebar3#compatibility-between-operating-system-and-erlangotp

It would be great to support latest versions of Elixir/Erlang and maybe deprecate others? I'll try to make a PR with that shortly.