### PR TITLE
[Fix] Flaky use test

### DIFF
--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -1,0 +1,7 @@
+defmodule BoomNotifier.Case do
+  use ExUnit.CaseTemplate
+
+  setup do
+    BoomNotifier.TestMessageProxy.subscribe(self())
+  end
+end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -1,4 +1,6 @@
 defmodule BoomNotifier.Case do
+  @moduledoc false
+
   use ExUnit.CaseTemplate
 
   setup do

--- a/test/support/test_message_proxy.ex
+++ b/test/support/test_message_proxy.ex
@@ -1,0 +1,59 @@
+defmodule BoomNotifier.TestMessageProxy do
+  @moduledoc """
+  A gen server that forwards messages to subscribed pids.
+  Usefull to send responses to test example processes.
+
+  Example:
+
+  use BoomNotifier.Case
+
+  test "receive a message from elsewhere" do
+    spawn_link(fn -> send(Process.whereis(BoomNotifier.TestMessageProxy), :message) end)
+
+    assert_receive(:message)
+  end
+  """
+  use GenServer
+
+  def subscribe(pid) do
+    GenServer.call(__MODULE__, {:subscribe, pid}, 100)
+  end
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def stop(reason \\ :shutdown) do
+    GenServer.stop(__MODULE__, reason)
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, []}
+  end
+
+  @impl true
+  def handle_call({:subscribe, pid}, _from, state) do
+    Process.monitor(pid)
+
+    {:reply, :ok, [pid | state] |> Enum.uniq()}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, Enum.reject(state, &(&1 == pid))}
+  end
+
+  def handle_info(message, state) do
+    broadcast(message, state)
+
+    {:noreply, state}
+  end
+
+  defp broadcast(_message, []), do: nil
+
+  defp broadcast(message, [pid | rest]) do
+    send(pid, message)
+    broadcast(message, rest)
+  end
+end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -6,4 +6,14 @@ defmodule TestUtils do
   def above_version?(boundary) do
     Version.compare(System.version(), boundary) == :gt
   end
+
+  def force_register_pid(pid, name) do
+    unregister_pid(name)
+    Process.register(pid, name)
+  end
+
+  def unregister_pid(name) do
+    if Process.whereis(name),
+      do: Process.unregister(name)
+  end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -7,7 +7,7 @@ defmodule TestUtils do
     Version.compare(System.version(), boundary) == :gt
   end
 
-  def force_register_pid(pid, name) do
+  def register_pid_override(pid, name) do
     unregister_pid(name)
     Process.register(pid, name)
   end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -6,14 +6,4 @@ defmodule TestUtils do
   def above_version?(boundary) do
     Version.compare(System.version(), boundary) == :gt
   end
-
-  def register_pid_override(pid, name) do
-    unregister_pid(name)
-    Process.register(pid, name)
-  end
-
-  def unregister_pid(name) do
-    if Process.whereis(name),
-      do: Process.unregister(name)
-  end
 end

--- a/test/unit/test_helper.exs
+++ b/test/unit/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start()
+BoomNotifier.TestMessageProxy.start_link()
 Application.ensure_all_started(:bypass)

--- a/test/unit/use_test.exs
+++ b/test/unit/use_test.exs
@@ -17,7 +17,10 @@ defmodule BoomNotifier.UseTest do
   end
 
   setup do
-    force_register_pid(self(), BoomNotifier.UseTest)
+    # Even though tests are run sequentially a test example
+    # pid might ocationally be still alive when the next test
+    # example starts
+    register_pid_override(self(), BoomNotifier.UseTest)
 
     %{conn: Plug.Test.conn(:get, "/") |> Map.put(:owner, self())}
   end

--- a/test/unit/use_test.exs
+++ b/test/unit/use_test.exs
@@ -1,13 +1,11 @@
 defmodule BoomNotifier.UseTest do
-  use ExUnit.Case
-
-  import TestUtils
+  use BoomNotifier.Case
 
   @already_sent {:plug_conn, :sent}
 
   defmodule Notifier do
     def notify(%{name: name}, _) do
-      pid = Process.whereis(BoomNotifier.UseTest)
+      pid = Process.whereis(BoomNotifier.TestMessageProxy)
       send(pid, {:notification_sent, name})
     end
   end
@@ -17,11 +15,6 @@ defmodule BoomNotifier.UseTest do
   end
 
   setup do
-    # Even though tests are run sequentially a test example
-    # pid might ocationally be still alive when the next test
-    # example starts
-    register_pid_override(self(), BoomNotifier.UseTest)
-
     %{conn: Plug.Test.conn(:get, "/") |> Map.put(:owner, self())}
   end
 

--- a/test/unit/use_test.exs
+++ b/test/unit/use_test.exs
@@ -1,6 +1,8 @@
 defmodule BoomNotifier.UseTest do
   use ExUnit.Case
 
+  import TestUtils
+
   @already_sent {:plug_conn, :sent}
 
   defmodule Notifier do
@@ -15,7 +17,7 @@ defmodule BoomNotifier.UseTest do
   end
 
   setup do
-    Process.register(self(), BoomNotifier.UseTest)
+    force_register_pid(self(), BoomNotifier.UseTest)
 
     %{conn: Plug.Test.conn(:get, "/") |> Map.put(:owner, self())}
   end


### PR DESCRIPTION
There's an infrequent error in `use_test.exs`. ExUnit run each test example in their own process sequentially, but it can happen that before one test example process exists the next example pid starts and so the setup callback which registers the test example pid fails because the name is already in the registry.

CI error: https://github.com/wyeworks/boom/actions/runs/10408831846/job/28827080431?pr=93#step:11:89

## Solution

I've added a gen server that forwards messages to processes so we can subscribe the test pid on setup and send test messages to the genserver.

## Alternative solution

- Check if the name is registered and unregister before registering the new pid