### PR TITLE
[Fix] e2e flaky test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ erl_crash.dump
 boom-*.tar
 
 .DS_Store
-priv/
+/priv/


### PR DESCRIPTION
When navigating to the example app pages, the request for the favicon.ico raises a not found error which is catched by boom and it's not expected by tests