### PR TITLE
[Feature] Time error groupping

### DIFF
--- a/lib/boom_notifier/notification_sender.ex
+++ b/lib/boom_notifier/notification_sender.ex
@@ -14,45 +14,46 @@ defmodule BoomNotifier.NotificationSender do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
-  def async_notify(notifier, occurrences, options) do
-    GenServer.cast(__MODULE__, {:notify, notifier, occurrences, options})
-  end
-
   def async_trigger_notify(settings, error_info) do
     GenServer.cast(__MODULE__, {:trigger_notify, settings, error_info})
   end
 
-  def notify(notifier, occurrences, options) do
-    spawn_link(fn ->
-      notifier.notify(occurrences, options)
-    end)
-  end
+  def trigger_notify(settings, error_info) do
+    ErrorStorage.accumulate(error_info)
 
-  def notify_all(settings, error_info) do
-    notification_trigger = Keyword.get(settings, :notification_trigger, :always)
-    occurrences = ErrorStorage.reset_stats(error_info, notification_trigger)
-    error_info = Map.put(error_info, :occurrences, occurrences)
-
-    BoomNotifier.walkthrough_notifiers(
+    do_trigger_notify(
+      Keyword.get(settings, :groupping, :count),
       settings,
-      fn notifier, options -> notify(notifier, error_info, options) end
+      error_info
     )
   end
 
-  def trigger_notify(settings, error_info) do
-    timeout = Keyword.get(settings, :time_limit)
-
-    ErrorStorage.store_error(error_info)
+  defp do_trigger_notify(:count, settings, error_info) do
+    time_limit = Keyword.get(settings, :time_limit)
 
     if ErrorStorage.send_notification?(error_info) do
       notify_all(settings, error_info)
       :ok
     else
-      if timeout do
-        {:schedule, timeout}
+      if time_limit do
+        {:schedule, time_limit}
       else
-        :ok
+        :ignored
       end
+    end
+  end
+
+  defp do_trigger_notify(:time, settings, error_info) do
+    throttle = Keyword.get(settings, :throttle, 100)
+    time_limit = Keyword.get(settings, :time_limit)
+
+    stats = ErrorStorage.get_stats(error_info)
+
+    if ErrorStorage.eleapsed(stats) >= time_limit do
+      notify_all(settings, error_info)
+      :ok
+    else
+      {:schedule, throttle}
     end
   end
 
@@ -78,6 +79,9 @@ defmodule BoomNotifier.NotificationSender do
     cancel_timer(timer)
 
     case trigger_notify(settings, error_info) do
+      :ignored ->
+        {:noreply, state}
+
       :ok ->
         {:noreply, state}
 
@@ -113,6 +117,25 @@ defmodule BoomNotifier.NotificationSender do
     notify_all(settings, error_info)
 
     {:noreply, state |> Map.delete(error_info.key)}
+  end
+
+  # Private methods
+
+  defp notify(notifier, occurrences, options) do
+    spawn_link(fn ->
+      notifier.notify(occurrences, options)
+    end)
+  end
+
+  defp notify_all(settings, error_info) do
+    count_strategy = Keyword.get(settings, :count)
+    occurrences = ErrorStorage.reset_stats(error_info, count_strategy)
+    error_info = Map.put(error_info, :occurrences, occurrences)
+
+    BoomNotifier.walkthrough_notifiers(
+      settings,
+      fn notifier, options -> notify(notifier, error_info, options) end
+    )
   end
 
   defp cancel_timer(nil), do: nil

--- a/test/example_app/lib/example_app_web/router.ex
+++ b/test/example_app/lib/example_app_web/router.ex
@@ -2,7 +2,7 @@ defmodule ExampleAppWeb.Router do
   use ExampleAppWeb, :router
 
   use BoomNotifier,
-    notification_trigger: [exponential: [limit: 8]],
+    count: [exponential: [limit: 8]],
     custom_data: [:assigns, :logger],
     ignore_exceptions: [IgnoreExceptionError],
     notifiers: [

--- a/test/unit/error_storage_test.exs
+++ b/test/unit/error_storage_test.exs
@@ -226,7 +226,7 @@ defmodule ErrorStorageTest do
              }
     end
 
-    test "does not increase the counter when notification_trigger is :always" do
+    test "does not increase the counter when count is :always" do
       ErrorStorage.accumulate(@error_info)
 
       ErrorStorage.reset_stats(@error_info, :always)

--- a/test/unit/notification_sender_test.exs
+++ b/test/unit/notification_sender_test.exs
@@ -10,6 +10,7 @@ defmodule BoomNotifier.NotificationSenderTest do
   }
 
   @time_limit 500
+  @throttle 500
   @receive_timeout 100
 
   @settings_basic [
@@ -17,11 +18,16 @@ defmodule BoomNotifier.NotificationSenderTest do
     options: [pid_name: BoomNotifier.TestMessageProxy]
   ]
 
-  @settings_groupping @settings_basic ++
-                        [
-                          time_limit: @time_limit,
-                          notification_trigger: :exponential
-                        ]
+  @settings_groupping_count @settings_basic ++
+                              [
+                                time_limit: @time_limit,
+                                count: :exponential
+                              ]
+  @settings_groupping_time @settings_basic ++
+                             [
+                               groupping: :time,
+                               throttle: @throttle
+                             ]
 
   defmodule NotificationSenderTestNotifier do
     def notify(error_info, opts) do
@@ -45,6 +51,11 @@ defmodule BoomNotifier.NotificationSenderTest do
       %{error_info: error_info}
   end
 
+  def notification_sent(error_info) do
+    ErrorStorage.accumulate(error_info)
+    ErrorStorage.reset_stats(error_info, :exponential)
+  end
+
   setup do
     clear_error_storage()
 
@@ -56,7 +67,7 @@ defmodule BoomNotifier.NotificationSenderTest do
 
   setup :build_error_info
 
-  describe "with default notification trigger (always)" do
+  describe "with default notification count (none)" do
     test "sends a notification", %{error_info: error_info} do
       NotificationSender.trigger_notify(@settings_basic, error_info)
 
@@ -65,19 +76,19 @@ defmodule BoomNotifier.NotificationSenderTest do
     end
   end
 
-  describe "sync call with exponential notification trigger" do
+  describe "sync call with exponential notification count" do
     test "sends a notification", %{error_info: error_info} do
-      NotificationSender.trigger_notify(@settings_groupping, error_info)
+      NotificationSender.trigger_notify(@settings_groupping_count, error_info)
 
       {_, rcv_error_info} = assert_receive({:notify_called, _}, @receive_timeout)
       assert Map.delete(rcv_error_info, :occurrences) == Map.delete(error_info, :occurrences)
     end
 
     test "does not send a second notification", %{error_info: error_info} do
-      ErrorStorage.store_error(error_info)
-      ErrorStorage.reset_stats(error_info, :exponential)
+      notification_sent(error_info)
 
-      trigger_notify_resp = NotificationSender.trigger_notify(@settings_groupping, error_info)
+      trigger_notify_resp =
+        NotificationSender.trigger_notify(@settings_groupping_count, error_info)
 
       refute_receive({:notify_called, _}, @receive_timeout)
       assert {:schedule, @time_limit} = trigger_notify_resp
@@ -85,7 +96,7 @@ defmodule BoomNotifier.NotificationSenderTest do
 
     test "sends notification occurrences along error info", %{error_info: error_info} do
       for _ <- 1..7 do
-        NotificationSender.trigger_notify(@settings_groupping, error_info)
+        NotificationSender.trigger_notify(@settings_groupping_count, error_info)
       end
 
       assert_receive({:notify_called, %{occurrences: %{accumulated_occurrences: 1}}})
@@ -94,33 +105,30 @@ defmodule BoomNotifier.NotificationSenderTest do
     end
   end
 
-  describe "async call with exponential notification trigger" do
+  describe "async call with exponential notification count" do
     test "sends a notification", %{error_info: error_info} do
-      NotificationSender.async_trigger_notify(@settings_groupping, error_info)
+      NotificationSender.async_trigger_notify(@settings_groupping_count, error_info)
 
       assert_receive({:notify_called, _}, @receive_timeout)
     end
   end
 
-  describe "repeated async call with exponential notification trigger" do
+  describe "repeated async call with exponential notification count" do
     setup(%{error_info: error_info}) do
-      ErrorStorage.store_error(error_info)
-      ErrorStorage.reset_stats(error_info, :exponential)
+      notification_sent(error_info)
 
       :ok
     end
 
     test "sends a second notification after a timeout", %{error_info: error_info} do
-      NotificationSender.async_trigger_notify(@settings_groupping, error_info)
+      NotificationSender.async_trigger_notify(@settings_groupping_count, error_info)
 
       assert_receive({:notify_called, _}, @time_limit + @receive_timeout)
-
-      assert error_info |> ErrorStorage.get_stats() |> Map.get(:accumulated_occurrences) ==
-               0
+      assert error_info |> ErrorStorage.get_stats() |> Map.get(:accumulated_occurrences) == 0
     end
 
     test "does not send a second notification before a timeout", %{error_info: error_info} do
-      NotificationSender.async_trigger_notify(@settings_groupping, error_info)
+      NotificationSender.async_trigger_notify(@settings_groupping_count, error_info)
 
       refute_receive({:notify_called, _}, @time_limit - 50)
 
@@ -131,9 +139,9 @@ defmodule BoomNotifier.NotificationSenderTest do
       "it does not sends a scheduled notification if another error happens",
       %{error_info: error_info}
     ) do
-      NotificationSender.async_trigger_notify(@settings_groupping, error_info)
-      NotificationSender.async_trigger_notify(@settings_groupping, error_info)
-      NotificationSender.async_trigger_notify(@settings_groupping, error_info)
+      NotificationSender.async_trigger_notify(@settings_groupping_count, error_info)
+      NotificationSender.async_trigger_notify(@settings_groupping_count, error_info)
+      NotificationSender.async_trigger_notify(@settings_groupping_count, error_info)
 
       notification_sender_state =
         NotificationSender
@@ -150,7 +158,7 @@ defmodule BoomNotifier.NotificationSenderTest do
       "it does not schedule a notification if time_limit is not specified",
       %{error_info: error_info}
     ) do
-      settings = Keyword.delete(@settings_groupping, :time_limit)
+      settings = Keyword.delete(@settings_groupping_count, :time_limit)
 
       NotificationSender.async_trigger_notify(settings, error_info)
       NotificationSender.async_trigger_notify(settings, error_info)
@@ -159,6 +167,60 @@ defmodule BoomNotifier.NotificationSenderTest do
       notification_sender_state = :sys.get_state(Process.whereis(NotificationSender))
 
       assert notification_sender_state |> Map.keys() |> length() == 0
+    end
+  end
+
+  describe "with time groupping" do
+    setup :build_error_info
+
+    test "it returns a schedule action", %{error_info: error_info} do
+      result = NotificationSender.trigger_notify(@settings_groupping_time, error_info)
+
+      assert {:schedule, @throttle} = result
+    end
+
+    test "it does not send the notification before throttle", %{error_info: error_info} do
+      NotificationSender.async_trigger_notify(@settings_groupping_time, error_info)
+
+      refute_receive({:notify_called, _}, @throttle - 50)
+    end
+
+    test "it sends the notification after throttle", %{error_info: error_info} do
+      NotificationSender.async_trigger_notify(@settings_groupping_time, error_info)
+
+      assert_receive({:notify_called, _}, @throttle + 50)
+    end
+
+    test "it throttles repeated error notifications", %{error_info: error_info} do
+      for _ <- 1..20 do
+        NotificationSender.async_trigger_notify(@settings_groupping_time, error_info)
+      end
+
+      state = :sys.get_state(NotificationSender)
+      assert_receive({:notify_called, _}, @throttle + 50)
+      error_key = error_info.key
+      assert %{^error_key => _} = state
+      assert state |> Map.keys() |> length() == 1
+    end
+
+    test "it sends a throttle notification if time limit is present", %{error_info: error_info} do
+      settings =
+        @settings_groupping_time
+        |> Keyword.merge(
+          throttle: 400,
+          time_limit: 100
+        )
+
+      for _ <- 1..3 do
+        NotificationSender.async_trigger_notify(
+          settings,
+          error_info |> Map.put(:timestamp, DateTime.utc_now())
+        )
+
+        :timer.sleep(100)
+      end
+
+      assert_received({:notify_called, _})
     end
   end
 end

--- a/test/unit/notifier_test.exs
+++ b/test/unit/notifier_test.exs
@@ -118,7 +118,7 @@ defmodule NotifierTest do
   defmodule PlugErrorWithExponentialTriggerNotifier do
     use BoomNotifier,
       notifier: FakeNotifier,
-      notification_trigger: :exponential,
+      count: :exponential,
       options: [
         subject: "BOOM error caught",
         sender_pid_name: TestMessageProxy
@@ -132,7 +132,7 @@ defmodule NotifierTest do
   defmodule PlugErrorWithExponentialTriggerWithLimitNotifier do
     use BoomNotifier,
       notifier: FakeNotifier,
-      notification_trigger: [exponential: [limit: 3]],
+      count: [exponential: [limit: 3]],
       options: [
         subject: "BOOM error caught",
         sender_pid_name: TestMessageProxy
@@ -229,7 +229,7 @@ defmodule NotifierTest do
     assert_receive(%{exception: %{subject: "BOOM error caught: thrown error"}}, @receive_timeout)
   end
 
-  test "reports exception in groups when :notification_trigger setting is :exponential" do
+  test "reports exception in groups when :count setting is :exponential" do
     conn = conn(:get, "/")
 
     catch_error(PlugErrorWithExponentialTriggerNotifier.call(conn, []))
@@ -239,11 +239,10 @@ defmodule NotifierTest do
     catch_error(PlugErrorWithExponentialTriggerNotifier.call(conn, []))
     assert_receive(%{exception: _}, @receive_timeout)
 
-    {:message_queue_len, exceptions} = Process.info(self(), :message_queue_len)
-    assert exceptions == 0
+    refute_receive(%{exception: _}, @receive_timeout)
   end
 
-  test "reports exception in groups when :notification_trigger setting is :exponential with limit" do
+  test "reports exception in groups when :count setting is :exponential with limit" do
     conn = conn(:get, "/")
 
     catch_error(PlugErrorWithExponentialTriggerWithLimitNotifier.call(conn, []))
@@ -263,11 +262,10 @@ defmodule NotifierTest do
     catch_error(PlugErrorWithExponentialTriggerWithLimitNotifier.call(conn, []))
     assert_receive(%{exception: _}, @receive_timeout)
 
-    {:message_queue_len, exceptions} = Process.info(self(), :message_queue_len)
-    assert exceptions == 0
+    refute_receive(%{exception: _}, @receive_timeout)
   end
 
-  test "reports every exception when :notification_trigger setting is not set" do
+  test "reports every exception when :count setting is not set" do
     conn = conn(:get, "/")
 
     catch_error(PlugErrorWithSingleNotifier.call(conn, []))


### PR DESCRIPTION
- Add a time throttling mechanism to prevent multiple errors to trigger notifications. It works by scheduling a notification after the last error until :throttle milliseconds have passed without an error or :time_limt milliseconds have passed from the first occurrence.